### PR TITLE
fix: add image metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Zenao",
   description: "Zenao.io - Events & Tribes Organizations",
+  openGraph: {
+    images: "/zenao-logo.png",
+  },
 };
 
 export default async function RootLayout({


### PR DESCRIPTION
Fix #146 
Image metadata by default, and event metadata correctly overwrite default ones 👍 

<img width="1357" alt="Screenshot 2025-01-27 at 17 21 16" src="https://github.com/user-attachments/assets/57c15b96-d3ee-4cfc-9d0b-ce2f267389e5" />