### PR TITLE
chore: Move SEO to page

### DIFF
--- a/app/create/CreateEventForm.tsx
+++ b/app/create/CreateEventForm.tsx
@@ -10,6 +10,7 @@ import { zenaoClient } from "@/app/zenao-client";
 import { eventFormSchema, EventFormSchemaType } from "@/components/form/types";
 import { EventForm } from "@/components/form/EventForm";
 import { useToast } from "@/app/hooks/use-toast";
+import { eventFormLocationValue } from "@/lib/event-location";
 
 export const CreateEventForm: React.FC = () => {
   const { getToken } = useAuth();
@@ -43,33 +44,15 @@ export const CreateEventForm: React.FC = () => {
       if (!token) {
         throw new Error("invalid clerk token");
       }
-      // Construct location object for the call
-      let value = {};
-      switch (values.location.kind) {
-        case "custom":
-          value = {
-            address: values.location.address,
-            timezone: values.location.timeZone,
-          };
-          break;
-        case "virtual":
-          value = { uri: values.location.location };
-          break;
-        case "geo":
-          value = {
-            address: values.location.address,
-            lat: values.location.lat,
-            lng: values.location.lng,
-            size: values.location.size,
-          };
-          break;
-        default:
-          value = {};
-      }
       const { id } = await zenaoClient.createEvent(
         {
           ...values,
-          location: { address: { case: values.location.kind, value } },
+          location: {
+            address: {
+              case: values.location.kind,
+              value: eventFormLocationValue(values),
+            },
+          },
         },
         { headers: { Authorization: "Bearer " + token } },
       );

--- a/lib/event-location.ts
+++ b/lib/event-location.ts
@@ -1,0 +1,63 @@
+import { EventFormSchemaType } from "@/components/form/types";
+import { EventInfo } from "@/app/gen/zenao/v1/zenao_pb";
+import { currentTimezone } from "@/lib/time";
+
+// Correctly reconstruct location object
+export function eventLocation(event: EventInfo) {
+  let location: EventFormSchemaType["location"] = {
+    kind: "custom",
+    address: "",
+    timeZone: "",
+  };
+  switch (event.location?.address.case) {
+    case "custom":
+      location = {
+        kind: "custom",
+        address: event.location?.address.value.address,
+        timeZone: event.location?.address.value.timezone,
+      };
+      break;
+    case "geo":
+      location = {
+        kind: "geo",
+        address: event.location?.address.value.address,
+        lat: event.location?.address.value.lat,
+        lng: event.location?.address.value.lng,
+        size: event.location?.address.value.size,
+      };
+      break;
+    case "virtual":
+      location = {
+        kind: "virtual",
+        location: event.location?.address.value.uri,
+      };
+  }
+  return location;
+}
+
+// Construct location object for the call
+export function eventFormLocationValue(eventFormValues: EventFormSchemaType) {
+  let value = {};
+  switch (eventFormValues.location.kind) {
+    case "custom":
+      value = {
+        address: eventFormValues.location.address,
+        timezone: currentTimezone(),
+      };
+      break;
+    case "virtual":
+      value = { uri: eventFormValues.location.location };
+      break;
+    case "geo":
+      value = {
+        address: eventFormValues.location.address,
+        lat: eventFormValues.location.lat,
+        lng: eventFormValues.location.lng,
+        size: eventFormValues.location.size,
+      };
+      break;
+    default:
+      value = {};
+  }
+  return value;
+}


### PR DESCRIPTION
#### Move SEO stuff in `generateMetadata` in `page.tsx`
https://github.com/samouraiworld/zenao/pull/270/files#diff-79534d80d2137a0a7dd794d0c62dc1c435d049408438bcc7245539dd998089f2L127-L130
It's more optimized for NextJS and allows to keep `event-info.tsx` clean from SO stuff

#### Factorize location object contruction
https://github.com/samouraiworld/zenao/pull/270/files#diff-b7f650d2d50b7993e3babfc53d1c573f5a9bfd6db49bac8c27f9646b93a588ebR5-R63
Just repeated code factorization. 
I can remove that from this PR.
I just did that because `jsonLd` uses a `location` JS object: https://github.com/samouraiworld/zenao/pull/270/files#diff-0cd72a447757ce198689a1b1798d681f52f3d46c2deea1147d895dc1334cb05bR32