### PR TITLE
fix: FormMessage positions

### DIFF
--- a/components/form/components/FormFieldImage.tsx
+++ b/components/form/components/FormFieldImage.tsx
@@ -60,31 +60,33 @@ export const FormFieldImage = <T extends FieldValues>(
       control={props.control}
       name={props.name}
       render={() => (
-        <FormItem className="space-y-0 flex flex-col w-full sm:w-2/5">
-          {/* We have to check if the URL is valid here because the error message is updated after the value and Image cannot take a wrong URL (throw an error instead) */}
-          {/* TODO: find a better way */}
-          {isValidURL(imageUri, urlPattern) && !fieldState.error?.message ? (
-            <Image
-              src={web2URL(imageUri)}
-              width={330}
-              height={330}
-              alt="imageUri"
-              className="flex w-full rounded-xl self-center border"
-            />
-          ) : (
-            <Skeleton className="w-full h-[330px] rounded-xnter flex justify-center items-center border">
-              {uploading && <Loader2 className="animate-spin" />}
-            </Skeleton>
-          )}
-          <div className="self-end relative bottom-8 right-2">
-            <ImageIcon onClick={handleClick} className="w-5 cursor-pointer" />
-            <input
-              type="file"
-              onChange={handleChange}
-              ref={hiddenInputRef}
-              className="hidden"
-              disabled={uploading}
-            />
+        <FormItem className="flex flex-col w-full sm:w-2/5 h-fit">
+          <div className="relative">
+            {/* We have to check if the URL is valid here because the error message is updated after the value and Image cannot take a wrong URL (throw an error instead) */}
+            {/* TODO: find a better way */}
+            {isValidURL(imageUri, urlPattern) && !fieldState.error?.message ? (
+              <Image
+                src={web2URL(imageUri)}
+                width={330}
+                height={330}
+                alt="imageUri"
+                className="flex w-full rounded-xl self-center border"
+              />
+            ) : (
+              <Skeleton className="w-full h-[330px] rounded-xnter flex justify-center items-center border">
+                {uploading && <Loader2 className="animate-spin" />}
+              </Skeleton>
+            )}
+            <div className="absolute bottom-2 right-2">
+              <ImageIcon onClick={handleClick} className="w-5 cursor-pointer" />
+              <input
+                type="file"
+                onChange={handleChange}
+                ref={hiddenInputRef}
+                className="hidden"
+                disabled={uploading}
+              />
+            </div>
           </div>
           <FormMessage />
         </FormItem>

--- a/components/form/components/FormFieldLocation.tsx
+++ b/components/form/components/FormFieldLocation.tsx
@@ -72,7 +72,7 @@ export const FormFieldLocation: React.FC<{
       render={({ field }) => {
         const object = field.value as z.infer<typeof addressLocationSchema>;
         return (
-          <FormItem className="flex flex-col w-full space-y-0 gap-0 space-x-2">
+          <FormItem className="flex flex-col w-full gap-0">
             <Popover open={open} onOpenChange={setOpen}>
               <div className="flex flex-row w-full justify-between">
                 <PopoverTrigger asChild>
@@ -186,7 +186,7 @@ export const FormFieldLocation: React.FC<{
                 </Command>
               </PopoverContent>
             </Popover>
-            <FormMessage className="pb-2 pt-2" />
+            <FormMessage className="pb-2 px-4" />
           </FormItem>
         );
       }}

--- a/components/form/components/FormFieldTextArea.tsx
+++ b/components/form/components/FormFieldTextArea.tsx
@@ -70,10 +70,13 @@ export const FormFieldTextArea = <T extends FieldValues>({
           >
             <FormMessage />
             {wordCounter && (
-              <Text size="sm" className="text-primary-color/80">
-                <span>{field.value.length}</span> /
-                <span>{otherProps.maxLength}</span>
-              </Text>
+              <>
+                <div />
+                <Text size="sm" className="text-primary-color/80">
+                  <span>{field.value.length}</span> /
+                  <span>{otherProps.maxLength}</span>
+                </Text>
+              </>
             )}
           </div>
         </FormItem>

--- a/components/form/components/form-field-date-picker.tsx
+++ b/components/form/components/form-field-date-picker.tsx
@@ -133,7 +133,7 @@ export function FormFieldDatePicker<T extends FieldValues>(
         render={({ field }) => {
           const formattedValue = fromUnixTime(Number(field.value));
           return (
-            <FormItem className="flex flex-col w-full space-y-0">
+            <FormItem className="flex flex-col w-full">
               <Popover open={isOpen} onOpenChange={setIsOpen}>
                 <PopoverTrigger asChild>
                   <FormControl>
@@ -209,7 +209,7 @@ export function FormFieldDatePicker<T extends FieldValues>(
         render={({ field }) => {
           const formattedValue = fromUnixTime(Number(field.value));
           return (
-            <FormItem className="flex flex-col space-y-0">
+            <FormItem className="flex flex-col">
               <FormControl>
                 <Select
                   disabled={props.disabled || !field.value}

--- a/components/form/components/form-field-date-picker.tsx
+++ b/components/form/components/form-field-date-picker.tsx
@@ -133,7 +133,7 @@ export function FormFieldDatePicker<T extends FieldValues>(
         render={({ field }) => {
           const formattedValue = fromUnixTime(Number(field.value));
           return (
-            <FormItem className="flex flex-col w-full">
+            <FormItem className="flex flex-col w-full space-y-0">
               <Popover open={isOpen} onOpenChange={setIsOpen}>
                 <PopoverTrigger asChild>
                   <FormControl>
@@ -209,7 +209,7 @@ export function FormFieldDatePicker<T extends FieldValues>(
         render={({ field }) => {
           const formattedValue = fromUnixTime(Number(field.value));
           return (
-            <FormItem className="flex flex-col">
+            <FormItem className="flex flex-col space-y-0">
               <FormControl>
                 <Select
                   disabled={props.disabled || !field.value}

--- a/components/shadcn/form.tsx
+++ b/components/shadcn/form.tsx
@@ -150,7 +150,7 @@ const FormMessage = React.forwardRef<
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message) : children;
   if (!body) {
-    return <span className="w-0 h-0" />;
+    return null;
   }
 
   return (


### PR DESCRIPTION
Modifying  [form.tsx from shadcb](https://github.com/samouraiworld/zenao/blob/603377df9bdee42f4845c72722cb704059ccb903/components/shadcn/form.tsx) just bothers me a little, but I don't how they place `FormMessage`.
Discussed with @pr0m3th3usEx , thx for your suggestion. This PR is more pertinent now


#### `FormMessage` positions and spaces fixed
![image](https://github.com/user-attachments/assets/1eb740bf-c70b-4df4-8176-df228147d8df)

