### PR TITLE
fix(front): Avoid event start date to be at a time in the past

### DIFF
--- a/components/form/event-form.tsx
+++ b/components/form/event-form.tsx
@@ -210,6 +210,15 @@ export const EventForm: React.FC<EventFormProps> = ({
                     ]
                   : []),
               ]}
+              disabledHours={[
+                ...(minDateRange
+                  ? [
+                      {
+                        before: minDateRange,
+                      },
+                    ]
+                  : []),
+              ]}
             />
             <FormFieldDatePicker
               name="endDate"


### PR DESCRIPTION
Fix the case when you can select a startDate as today but hours or minutes before now