### PR TITLE
fix(back): broadcast send email to all the user base

### DIFF
--- a/backend/broadcast_event.go
+++ b/backend/broadcast_event.go
@@ -64,6 +64,10 @@ func (s *ZenaoServer) BroadcastEvent(
 		return nil, err
 	}
 
+	if len(participants) == 0 {
+		return nil, errors.New("a broadcast message cannot be sent to an event without any participants")
+	}
+
 	idsList := make([]string, len(participants))
 	for i, participant := range participants {
 		idsList[i] = participant.AuthID


### PR DESCRIPTION
if it was no participants, so empty id list clerk returned the list of all users resulting in sending an email to everyone
now, if there no participants in the event then the broadcast returns an error