### PR TITLE
fix(feed): Prevent double click on reaction

### DIFF
--- a/components/cards/social-feed/post-card-layout.tsx
+++ b/components/cards/social-feed/post-card-layout.tsx
@@ -124,7 +124,7 @@ function Reactions({
   const isParticipant = useMemo(() => roles.includes("participant"), [roles]);
 
   const [emojiPickerOpen, setEmojiPickerOpen] = React.useState(false);
-  const { reactPost } = useReactPost(queryClient);
+  const { reactPost, isPending } = useReactPost(queryClient);
   const onReactionChange = async (icon: string) => {
     try {
       const token = await getToken();
@@ -159,6 +159,7 @@ function Reactions({
             <EmojiPicker
               theme={Theme.DARK}
               onEmojiClick={(choice) => {
+                if (isPending) return;
                 onReactionChange(choice.emoji);
                 setEmojiPickerOpen(false);
               }}
@@ -170,6 +171,7 @@ function Reactions({
       {reactions.map((reaction) => (
         <div
           onClick={() => {
+            if (isPending) return;
             if (reaction.userHasVoted) onReactionChange(reaction.icon);
           }}
           className={cn(


### PR DESCRIPTION
Merge to `main` after #246 

Fix #406 

**Changes made**

- Prevent other reaction mutations to be sent when one currently on going

**FYI**
- Failed to reproduce bug: one hypothesis we emitted was related to double click on reaction
