### PR TITLE
fix(poll): Change color and adapt for light theme

### DIFF
--- a/components/cards/social-feed/poll-post-card.tsx
+++ b/components/cards/social-feed/poll-post-card.tsx
@@ -146,10 +146,10 @@ function PollResultItem({
       variant="outline"
       disabled={disabled}
       className={cn(
-        "flex items-center justify-between gap-2 px-4 w-full h-10 relative rounded-lg bg-transparent",
-        !disabled && "hover:opacity-50 cursor-pointer",
-        disabled && "hover:bg-transparent cursor-not-allowed",
-        pollResult.hasUserVoted && "border border-gray-600",
+        "flex items-center justify-between gap-2 px-4 w-full h-10 relative rounded-lg hover:bg-transparent bg-transparent",
+        !disabled && !pollResult.hasUserVoted && "hover:border-neutral-500",
+        !disabled && "cursor-pointer",
+        pollResult.hasUserVoted && "border border-[#EC7E17]",
       )}
       onClick={() => {
         if (!disabled) {
@@ -158,16 +158,12 @@ function PollResultItem({
       }}
     >
       <div>
-        <Gauge percent={percent} className="absolute -z-10 left-0" />
+        <Gauge
+          percent={percent}
+          className="absolute -z-10 left-0 bg-neutral-200/50 dark:bg-neutral-800/50"
+        />
 
-        <Text
-          className={cn(
-            "text-sm line-clamp-2",
-            pollResult.hasUserVoted && "text-white",
-          )}
-        >
-          {pollResult.option}
-        </Text>
+        <Text className="text-sm line-clamp-2">{pollResult.option}</Text>
 
         <div className="flex flex-row items-center gap-3">
           <div className="flex flex-row items-center gap-2">
@@ -176,10 +172,11 @@ function PollResultItem({
           </div>
           <Checkbox
             ref={checkboxRef}
+            disabled={disabled}
             checked={pollResult.hasUserVoted}
             onCheckedChange={onCheckedChange}
             className={cn(
-              disabled ? "cursor-default" : "cursor-pointer",
+              "cursor-pointer disabled:opacity-100 disabled:cursor-default",
               pollKind === PollKind.SINGLE_CHOICE && "rounded-lg",
             )}
           />

--- a/components/cards/social-feed/poll-post-card.tsx
+++ b/components/cards/social-feed/poll-post-card.tsx
@@ -149,7 +149,7 @@ function PollResultItem({
         "flex items-center justify-between gap-2 px-4 w-full h-10 relative rounded-lg hover:bg-transparent bg-transparent",
         !disabled && !pollResult.hasUserVoted && "hover:border-neutral-500",
         !disabled && "cursor-pointer",
-        pollResult.hasUserVoted && "border border-[#EC7E17]",
+        pollResult.hasUserVoted && "border border-custom-input-border",
       )}
       onClick={() => {
         if (!disabled) {

--- a/components/common/gauge.tsx
+++ b/components/common/gauge.tsx
@@ -10,9 +10,9 @@ export function Gauge({
   className?: string;
 }) {
   return (
-    <div className={cn("flex w-full h-10 rounded-lg bg-muted", className)}>
+    <div className={cn("flex w-full h-10 rounded-lg", className)}>
       <div
-        className="rounded-lg h-full bg-gray-700"
+        className="rounded-lg h-full bg-[#EC7E17]/30"
         style={{ width: `${percent}%` }}
       />
     </div>


### PR DESCRIPTION
You'll see above, in a poll with 5 results:
- A result with no vote 
- A result not voted by the user
- A result with no vote, hovered
- A result with no vote
- A result voted by the user

## Dark theme 
![image](https://github.com/user-attachments/assets/355a9a3c-c794-4531-ad97-4ebc04cb41db)

## Light theme
![image](https://github.com/user-attachments/assets/4230cef9-2366-4748-8457-1921d0fdd2c2)
