### PR TITLE
feat(gno): add endpoint to query one post

### DIFF
--- a/gno/r/social_feed/json.gno
+++ b/gno/r/social_feed/json.gno
@@ -17,3 +17,12 @@ func postViewsToJSON(posts []*feedsv1.PostView) string {
 	}
 	return string(bz)
 }
+
+func postViewToJSON(post *feedsv1.PostView) string {
+	node := post.ToJSON()
+	bz, err := json.Marshal(node)
+	if err != nil {
+		panic(err)
+	}
+	return string(bz)
+}

--- a/gno/r/social_feed/posts.gno
+++ b/gno/r/social_feed/posts.gno
@@ -142,3 +142,11 @@ func GetPostReactions(localPostId uint64, user string) []*feedsv1.ReactionView {
 	return res
 
 }
+
+func GetPostView(localPostId uint64, user string) *feedsv1.PostView {
+	return &feedsv1.PostView{
+		Post:          GetPost(localPostId),
+		Reactions:     GetPostReactions(localPostId, user),
+		ChildrenCount: CountChildren(localPostId),
+	}
+}


### PR DESCRIPTION
following dicussion with Mio

example of query:

```
gnokey query vm/qeval -remote "tcp://127.0.0.1:26657" -data "gno.land/r/zenao/social_feed.postViewToJSON(GetPostView(1, \"g1cjkwzxyzhgd7c0797r7krhqpm84537stmt2x94\"))"
```