### PR TITLE
fix(back): secure clerk list users endpoint with empty ids

### DIFF
--- a/backend/czauth/auth.go
+++ b/backend/czauth/auth.go
@@ -37,6 +37,9 @@ func (c *clerkZenaoAuth) GetUser(ctx context.Context) *zeni.AuthUser {
 
 // GetUsersFromIDs implements zeni.Auth.
 func (c *clerkZenaoAuth) GetUsersFromIDs(ctx context.Context, ids []string) ([]*zeni.AuthUser, error) {
+	if len(ids) == 0 {
+		return []*zeni.AuthUser{}, nil
+	}
 	userList, err := user.List(ctx, &user.ListParams{UserIDs: ids})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
just block the possibility to list all users since empty ids means they will return the whole user base
it made me re-do a mistake i already did