### PR TITLE
feat(chain): retrieve event pkg path by addr

### DIFF
--- a/gno/r/eventreg/eventreg.gno
+++ b/gno/r/eventreg/eventreg.gno
@@ -17,12 +17,14 @@ var (
 	Ownable *ownable.Ownable
 
 	registered          avl.Tree // <eventPkgPath> -> func() events.Info
-	eventsPkgPathByAddr avl.Tree // <eventAddr> -> pkgPath
 	eventsByPkgPath     avl.Tree // <eventPkgPath> -> events.Info
 	eventsByEndDate     avl.Tree // <endDateUnixSeconds>/<eventPkgPath> -> eventPkgPath
 	eventsByParticipant avl.Tree // <participantID>/<endDateUnixSeconds>/<eventPkgPath> -> eventPkgPath
 	eventsByOrganizer   avl.Tree // <organizerID>/<endDateUnixSeconds>/<eventPkgPath> -> eventPkgPath
 	participantsByEvent avl.Tree // <eventPkgPath>/<participantID> -> participantID
+
+	// TODO: Remove this when we have a better way to handle lookup by event address.
+	eventsPkgPathByAddr avl.Tree // <eventAddr> -> pkgPath
 )
 
 func init() {
@@ -39,8 +41,11 @@ func Register(infoGetter events.InfoGetter) {
 		// XXX: remove from index??
 		return
 	}
-
 	registered.Set(pkgPath, infoGetter)
+
+	// TODO: Remove this when we have a better way to handle lookup by event address.
+	addr := std.DerivePkgAddr(pkgPath)
+	eventsPkgPathByAddr.Set(addr.String(), pkgPath)
 }
 
 func getInfo(pkgPath string) (*zenaov1.EventInfo, bool) {
@@ -175,6 +180,19 @@ func mustGetEventByPkgPath(pkgPath string) *zenaov1.EventInfo {
 		panic(ErrEventNotFound)
 	}
 	return evt
+}
+
+// TODO: Remove this when we have a better way to handle lookup by event address.
+func listEventsPkgPathByAddrs(addresses []string) []string {
+	res := make([]string, 0, len(addresses))
+	for _, addr := range addresses {
+		if pkgPath, ok := eventsPkgPathByAddr.Get(addr); ok {
+			res = append(res, pkgPath.(string))
+		} else {
+			res = append(res, "")
+		}
+	}
+	return res
 }
 
 func listEvents(from, to int64, limit, offset uint32) []*zenaov1.EventInfo {

--- a/gno/r/eventreg/eventreg.gno
+++ b/gno/r/eventreg/eventreg.gno
@@ -189,7 +189,7 @@ func listEventsPkgPathByAddrs(addresses []string) []string {
 		if pkgPath, ok := eventsPkgPathByAddr.Get(addr); ok {
 			res = append(res, pkgPath.(string))
 		} else {
-			res = append(res, "")
+			panic("event not found for address: " + addr)
 		}
 	}
 	return res

--- a/gno/r/eventreg/eventreg.gno
+++ b/gno/r/eventreg/eventreg.gno
@@ -17,6 +17,7 @@ var (
 	Ownable *ownable.Ownable
 
 	registered          avl.Tree // <eventPkgPath> -> func() events.Info
+	eventsPkgPathByAddr avl.Tree // <eventAddr> -> pkgPath
 	eventsByPkgPath     avl.Tree // <eventPkgPath> -> events.Info
 	eventsByEndDate     avl.Tree // <endDateUnixSeconds>/<eventPkgPath> -> eventPkgPath
 	eventsByParticipant avl.Tree // <participantID>/<endDateUnixSeconds>/<eventPkgPath> -> eventPkgPath
@@ -64,7 +65,6 @@ func IndexEvent(pkgPath string) {
 	if prev := getEventByPkgPath(pkgPath); prev != nil {
 		panic("already added")
 	}
-
 	info := mustGetInfo(pkgPath)
 	key := pkgPath
 	eventsByPkgPath.Set(key, info)


### PR DESCRIPTION
example:

```
gnokey query vm/qeval \  
  -remote tcp://127.0.0.1:26657 \ 
  -data 'gno.land/r/zenao/eventreg.listEventsPkgPathByAddrs([]string{"g1qwes3nes2ygx9wl38pvwa83yj2x7ynfm3vp9k8"})'

height: 0
data: (slice[("gno.land/r/zenao/events/e12" string)] []string)
```