### PR TITLE
fix: allow to re-join community after gentx

### DIFF
--- a/backend/gzdb/db.go
+++ b/backend/gzdb/db.go
@@ -970,7 +970,7 @@ func (g *gormZenaoDB) AddMemberToCommunity(communityID string, userID string) er
 		Role:       zeni.RoleMember,
 	}
 
-	if err := g.db.Create(entityRole).Error; err != nil {
+	if err := g.db.Save(entityRole).Error; err != nil {
 		return fmt.Errorf("create member role assignment in db: %w", err)
 	}
 


### PR DESCRIPTION
attempting to join a community that was left before gentxs happen result in `Create` conflict due to soft-delete, this uses `Save` instead