### PR TITLE
feat(front): improve gatekeeper add button UX

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -124,7 +124,8 @@
     "default": "Default (You)",
     "toast-gatekeeper-management-success": "Gatekeepers successfully updated!",
     "toast-gatekeeper-management-error": "Error while updating gatekeepers!",
-    "done": "Done"
+    "done": "Done",
+    "click-add-hint": "Click + to add this gatekeeper"
   },
   "manifesto": {
     "title": "MANIFESTO",

--- a/components/dialogs/gatekeeper-management-dialog.tsx
+++ b/components/dialogs/gatekeeper-management-dialog.tsx
@@ -69,6 +69,9 @@ function GatekeeperManagementForm({
     internalForm.reset();
   };
 
+  const isAddButtonEnabled =
+    internalForm.formState.isValid && internalForm.formState.isDirty;
+
   return (
     <Form {...internalForm}>
       <form
@@ -87,18 +90,20 @@ function GatekeeperManagementForm({
           <div className="col-span-1">
             <Button
               type="submit"
-              variant="outline"
+              variant={isAddButtonEnabled ? "default" : "outline"}
               aria-label="add gatekeeper"
-              disabled={
-                !internalForm.formState.isValid ||
-                !internalForm.formState.isDirty
-              }
+              disabled={!isAddButtonEnabled}
               className="aspect-square w-full h-12"
             >
               <Plus className="w-4 h-4" />
             </Button>
           </div>
         </div>
+        {isAddButtonEnabled && (
+          <Text className="text-xs text-muted-foreground -mt-1">
+            Click + to add this gatekeeper
+          </Text>
+        )}
       </form>
 
       <ol className="w-full list-decimal">

--- a/components/dialogs/gatekeeper-management-dialog.tsx
+++ b/components/dialogs/gatekeeper-management-dialog.tsx
@@ -101,7 +101,7 @@ function GatekeeperManagementForm({
         </div>
         {isAddButtonEnabled && (
           <Text className="text-xs text-muted-foreground -mt-1">
-            Click + to add this gatekeeper
+            {t("click-add-hint")}
           </Text>
         )}
       </form>


### PR DESCRIPTION
Closes https://github.com/samouraiworld/zenao/issues/719



### Before & After:

<img width="360" height="242" alt="Capture d’écran 2025-09-29 à 18 24 36" src="https://github.com/user-attachments/assets/4876faa7-34f2-401a-8b8c-a965e7c430d6" />

<img width="354" height="242" alt="Capture d’écran 2025-09-29 à 18 21 28" src="https://github.com/user-attachments/assets/03068504-7dee-466f-b765-7f38bd5d9834" />
