### PR TITLE
fix: show names instead of duplicate avatars on event page on mobile

### DIFF
--- a/app/event/[id]/(general)/[tab]/event-participants-section.tsx
+++ b/app/event/[id]/(general)/[tab]/event-participants-section.tsx
@@ -86,7 +86,7 @@ export function ParticipantsSection({ id }: { id: string }) {
                 : participantsAddresses
             }
           />
-          <UsersAvatarsPreview usersAddresses={participantsAddresses} />
+          <UsersNamesPreview usersAddresses={participantsAddresses} />
         </div>
       </DrawerTrigger>
 


### PR DESCRIPTION
Fixes #738 