### PR TITLE
fix: prevent layout shift in home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,7 +42,9 @@ export default function Home() {
             </ButtonWithChildren>
           </Link>
 
-          <LazyInstallButton />
+          <div className="h-[2.25rem]">
+            <LazyInstallButton />
+          </div>
         </div>
       </div>
     </ScreenContainerCentered>


### PR DESCRIPTION
in the home, the "install app" button is causing a layout shift, I couldn't make a suspense work, not sure why, but using a containing div with fixed height does the trick