### PR TITLE
chore: shared ssr query client

### DIFF
--- a/lib/get-query-client.ts
+++ b/lib/get-query-client.ts
@@ -4,6 +4,7 @@ import {
   defaultShouldDehydrateQuery,
   isServer,
 } from "@tanstack/react-query";
+import { cache } from "react";
 import { captureException } from "./report";
 
 function makeQueryClient() {
@@ -29,7 +30,8 @@ function makeQueryClient() {
 
 let browserQueryClient: QueryClient | undefined = undefined;
 
-export function getQueryClient() {
+// cache() is scoped per request, so we don't leak data between requests
+export const getQueryClient = cache(() => {
   if (isServer) {
     // Server: always make a new query client
     return makeQueryClient();
@@ -41,4 +43,4 @@ export function getQueryClient() {
     if (!browserQueryClient) browserQueryClient = makeQueryClient();
     return browserQueryClient;
   }
-}
+});

--- a/lib/get-query-client.ts
+++ b/lib/get-query-client.ts
@@ -31,6 +31,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined;
 
 // cache() is scoped per request, so we don't leak data between requests
+// see: https://tanstack.com/query/v5/docs/framework/react/guides/advanced-ssr#alternative-use-a-single-queryclient-for-prefetching
 export const getQueryClient = cache(() => {
   if (isServer) {
     // Server: always make a new query client


### PR DESCRIPTION
after profiling the frontend I realized that, on the server-side, queries are not always shared, using a shared client scoped by request ensures all queries are done only once on the server