### PR TITLE
fix: enable hint for aspect ratio

### DIFF
--- a/components/features/community/community-form.tsx
+++ b/components/features/community/community-form.tsx
@@ -69,7 +69,6 @@ export const CommunityForm = ({
             aspectRatio={isDesktop ? [48, 9] : [21, 9]}
             placeholder={t("upload-banner")}
             className="w-full rounded-xl overflow-hidden"
-            hint={false}
           />
           <div className="w-[96px] md:w-[128px] absolute -bottom-14 left-4 md:left-10">
             <FormFieldImage
@@ -78,7 +77,6 @@ export const CommunityForm = ({
               aspectRatio={[4, 4]}
               placeholder={t("upload-avatar")}
               className="w-full rounded-xl overflow-hidden"
-              hint={false}
             />
           </div>
         </div>


### PR DESCRIPTION
Closes https://github.com/samouraiworld/zenao/issues/766

On community edit page:

<img width="1176" height="350" alt="Capture d’écran 2025-10-06 à 18 49 33" src="https://github.com/user-attachments/assets/85354d9a-ff96-494e-bd6c-a529a0906f30" />
