### PR TITLE
fix(front): remark-vimeo-plugin - fix digits considered as vimeo ids

### DIFF
--- a/lib/remark-vimeo-plugin.ts
+++ b/lib/remark-vimeo-plugin.ts
@@ -26,10 +26,6 @@ function extractVimeoId(url: string): string | null {
   try {
     url = url.trim();
 
-    // If the value is just digits, don't assume it's the ID
-    const justDigits = url.match(/^\d+$/);
-    if (justDigits) return null;
-
     // Capture Vimeo ID from common URL forms:
     // - https://vimeo.com/12345678
     // - https://vimeo.com/channels/staffpicks/12345678


### PR DESCRIPTION
Fix #813 