### PR TITLE
fix(front): Clear community metadata description

### DIFF
--- a/app/community/[id]/layout.tsx
+++ b/app/community/[id]/layout.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({
 
   return {
     title: communityData.displayName,
-    description: communityData.description,
+    description: shortDescription || description || "",
     openGraph: {
       title: communityData.displayName,
       description: shortDescription || description || "",


### PR DESCRIPTION
Frontmatter header in description was not parsed.

Now using of shortDescription or description content

Before:

<img width="645" height="340" alt="Screenshot 2025-10-29 at 13 02 37" src="https://github.com/user-attachments/assets/7bed43a5-0408-4fc9-87a7-9e7954d52496" />

After:

<img width="645" height="340" alt="Screenshot 2025-10-29 at 13 02 47" src="https://github.com/user-attachments/assets/465fa8bc-8d2f-461c-9834-86c019fc9c72" />
