### PR TITLE
ci: restore the docker compose with git instead of yq

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,7 +46,6 @@ jobs:
             yq -iy 'del(.services.backend.command)' prod.backend.docker-compose.yml
             yq -iy '.services.backend |= ({"command": "--maintenance"} + .)' prod.backend.docker-compose.yml
             docker compose -f prod.backend.docker-compose.yml up -d backend
-            git restore prod.backend.docker-compose.yml
 
       - name: Backup DB
         shell: bash
@@ -97,10 +96,10 @@ jobs:
           host: 62.210.92.144
           username: root
           key: ${{ secrets.PROD_SSH_KEY }}
-          # the yq del is there to disable maintenance mode
+          # git restore is there to disable maintenance mode
           script: |
             set -xe
             cd zenao
             docker compose -f prod.backend.docker-compose.yml up -d --wait otel-collector jaeger
-            yq -iy 'del(.services.backend.command)' prod.backend.docker-compose.yml
+            git restore prod.backend.docker-compose.yml
             docker compose -f prod.backend.docker-compose.yml up -d --build backend

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,7 +46,6 @@ jobs:
             yq -iy 'del(.services.backend.command)' staging.docker-compose.yml
             yq -iy '.services.backend |= ({"command": "--maintenance"} + .)' staging.docker-compose.yml
             docker compose -f staging.docker-compose.yml up -d backend
-            git restore staging.docker-compose.yml
 
       - name: Backup DB
         shell: bash
@@ -84,11 +83,11 @@ jobs:
           host: 51.159.98.163
           username: root
           key: ${{ secrets.STAGING_SSH_KEY }}
-          # the yq del is there to disable maintenance mode
+          # git restore is there to disable maintenance mode
           script: |
             set -xe
             cd zenao
             docker compose -f staging.docker-compose.yml up -d --wait otel-collector jaeger
             docker compose -f staging.docker-compose.yml up -d --force-recreate --build gno --wait
-            yq -iy 'del(.services.backend.command)' staging.docker-compose.yml
+            git restore staging.docker-compose.yml
             docker compose -f staging.docker-compose.yml up -d --build backend


### PR DESCRIPTION
i suspect yq to let file modified with format modification, git restore on other hand will guarantee that the file is the same as at the start of the CI.