### PR TITLE
feat: add optional location-based filtering on Discover page

### DIFF
--- a/api/zenao/v1/zenao.proto
+++ b/api/zenao/v1/zenao.proto
@@ -133,6 +133,14 @@ message ListEventsRequest {
   int64 from = 3; // unix seconds
   int64 to = 4; // unix seconds
   DiscoverableFilter discoverable_filter = 5; // XXX: should we ensure events non discoverable are listed only if the user is an organizer?
+  LocationFilter location_filter = 6; // optional location filter
+}
+
+// Filter events by geographical location
+message LocationFilter {
+  float lat = 1; // latitude of the center point
+  float lng = 2; // longitude of the center point
+  float radius_km = 3; // radius in kilometers
 }
 
 message ListEventsResponse {

--- a/app/(general)/discover/discover-events-list.tsx
+++ b/app/(general)/discover/discover-events-list.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { format, fromUnixTime } from "date-fns";
-import { DEFAULT_EVENTS_LIMIT, eventsList } from "@/lib/queries/events-list";
+import {
+  DEFAULT_EVENTS_LIMIT,
+  eventsList,
+  LocationFilterParams,
+} from "@/lib/queries/events-list";
 import EmptyEventsList from "@/components/features/event/event-empty-list";
 import Text from "@/components/widgets/texts/text";
 import EventCardListLayout from "@/components/features/event/event-card-list-layout";
 import { EventCard } from "@/components/features/event/event-card";
 import { LoaderMoreButton } from "@/components/widgets/buttons/load-more-button";
+import { EventLocationFilter } from "@/components/features/event/event-location-filter";
 import { SafeEventInfo } from "@/types/schemas";
 
 export function DiscoverEventsList({
@@ -18,6 +23,17 @@ export function DiscoverEventsList({
   from: "upcoming" | "past";
   now: number;
 }) {
+  const [locationFilter, setLocationFilter] = useState<
+    LocationFilterParams | undefined
+  >(undefined);
+
+  const handleFilterChange = useCallback(
+    (filter: LocationFilterParams | undefined) => {
+      setLocationFilter(filter);
+    },
+    [],
+  );
+
   const {
     data: eventsPages,
     isFetchingNextPage,
@@ -26,10 +42,22 @@ export function DiscoverEventsList({
     fetchNextPage,
   } = useSuspenseInfiniteQuery(
     from === "upcoming"
-      ? eventsList(now, Number.MAX_SAFE_INTEGER, DEFAULT_EVENTS_LIMIT)
-      : eventsList(now - 1, 0, DEFAULT_EVENTS_LIMIT, {
-          staleTime: 1000 * 60, // 1 minute
-        }),
+      ? eventsList(
+          now,
+          Number.MAX_SAFE_INTEGER,
+          DEFAULT_EVENTS_LIMIT,
+          undefined,
+          locationFilter,
+        )
+      : eventsList(
+          now - 1,
+          0,
+          DEFAULT_EVENTS_LIMIT,
+          {
+            staleTime: 1000 * 60, // 1 minute
+          },
+          locationFilter,
+        ),
   );
 
   const events = useMemo(() => eventsPages.pages.flat(), [eventsPages]);
@@ -52,39 +80,46 @@ export function DiscoverEventsList({
     );
   }, [events]);
 
-  if (events.length === 0) {
-    return (
-      <div className="my-5">
-        <EmptyEventsList />
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-8">
-      {Object.entries(eventsByDay).map(([startOfDay, eventsOfTheDay]) => {
-        return (
-          <div key={startOfDay} className="flex flex-col gap-4">
-            <Text size="lg" className="font-semibold">
-              {format(startOfDay, "iiii d  MMM")}
-            </Text>
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <EventLocationFilter
+          onFilterChange={handleFilterChange}
+          currentFilter={locationFilter}
+        />
+      </div>
 
-            <EventCardListLayout>
-              {eventsOfTheDay.map((evt) => (
-                <EventCard key={evt.id} evt={evt} href={`/event/${evt.id}`} />
-              ))}
-            </EventCardListLayout>
-          </div>
-        );
-      })}
-      <LoaderMoreButton
-        fetchNextPage={fetchNextPage}
-        hasNextPage={hasNextPage}
-        isFetching={isFetching}
-        isFetchingNextPage={isFetchingNextPage}
-        page={events}
-        noMoreLabel={""}
-      />
+      {events.length === 0 ? (
+        <div className="my-5">
+          <EmptyEventsList />
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {Object.entries(eventsByDay).map(([startOfDay, eventsOfTheDay]) => {
+            return (
+              <div key={startOfDay} className="flex flex-col gap-4">
+                <Text size="lg" className="font-semibold">
+                  {format(startOfDay, "iiii d  MMM")}
+                </Text>
+
+                <EventCardListLayout>
+                  {eventsOfTheDay.map((evt) => (
+                    <EventCard key={evt.id} evt={evt} href={`/event/${evt.id}`} />
+                  ))}
+                </EventCardListLayout>
+              </div>
+            );
+          })}
+          <LoaderMoreButton
+            fetchNextPage={fetchNextPage}
+            hasNextPage={hasNextPage}
+            isFetching={isFetching}
+            isFetchingNextPage={isFetchingNextPage}
+            page={events}
+            noMoreLabel={""}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/app/gen/zenao/v1/zenao_pb.ts
+++ b/app/gen/zenao/v1/zenao_pb.ts
@@ -425,6 +425,13 @@ export type ListEventsRequest = Message<"zenao.v1.ListEventsRequest"> & {
    * @generated from field: zenao.v1.DiscoverableFilter discoverable_filter = 5;
    */
   discoverableFilter: DiscoverableFilter;
+
+  /**
+   * optional location filter
+   *
+   * @generated from field: zenao.v1.LocationFilter location_filter = 6;
+   */
+  locationFilter?: LocationFilter;
 };
 
 /**
@@ -461,6 +468,13 @@ export type ListEventsRequestJson = {
    * @generated from field: zenao.v1.DiscoverableFilter discoverable_filter = 5;
    */
   discoverableFilter?: DiscoverableFilterJson;
+
+  /**
+   * optional location filter
+   *
+   * @generated from field: zenao.v1.LocationFilter location_filter = 6;
+   */
+  locationFilter?: LocationFilterJson;
 };
 
 /**
@@ -469,6 +483,62 @@ export type ListEventsRequestJson = {
  */
 export const ListEventsRequestSchema: GenMessage<ListEventsRequest, {jsonType: ListEventsRequestJson}> = /*@__PURE__*/
   messageDesc(file_zenao_v1_zenao, 11);
+
+/**
+ * Filter events by geographical location
+ *
+ * @generated from message zenao.v1.LocationFilter
+ */
+export type LocationFilter = Message<"zenao.v1.LocationFilter"> & {
+  /**
+   * latitude of the center point
+   *
+   * @generated from field: float lat = 1;
+   */
+  lat: number;
+
+  /**
+   * longitude of the center point
+   *
+   * @generated from field: float lng = 2;
+   */
+  lng: number;
+
+  /**
+   * radius in kilometers
+   *
+   * @generated from field: float radius_km = 3;
+   */
+  radiusKm: number;
+};
+
+/**
+ * Filter events by geographical location
+ *
+ * @generated from message zenao.v1.LocationFilter
+ */
+export type LocationFilterJson = {
+  /**
+   * latitude of the center point
+   *
+   * @generated from field: float lat = 1;
+   */
+  lat?: number;
+
+  /**
+   * longitude of the center point
+   *
+   * @generated from field: float lng = 2;
+   */
+  lng?: number;
+
+  /**
+   * radius in kilometers
+   *
+   * @generated from field: float radius_km = 3;
+   */
+  radiusKm?: number;
+};
 
 /**
  * @generated from message zenao.v1.ListEventsResponse

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -358,7 +358,23 @@
   },
   "discover": {
     "title": "Discover events",
-    "description": "Dive into the pulse of tribes events, rave parties, hacking events, private cinema avant-premieres, and more."
+    "description": "Dive into the pulse of tribes events, rave parties, hacking events, private cinema avant-premieres, and more.",
+    "location-filter": {
+      "title": "Filter by location",
+      "description": "Show events near your location",
+      "filter-by-location": "Filter by location",
+      "nearby": "Within {radius} km",
+      "use-my-location": "Use my location",
+      "locating": "Getting location...",
+      "location-set": "Location set",
+      "radius": "Radius",
+      "clear-filter": "Clear filter",
+      "geolocation-not-supported": "Geolocation is not supported by your browser",
+      "permission-denied": "Location permission denied. Please enable it in your browser settings.",
+      "position-unavailable": "Location information is unavailable",
+      "timeout": "Location request timed out",
+      "unknown-error": "An unknown error occurred while getting your location"
+    }
   },
   "tickets": {
     "title": "Your tickets",

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -358,7 +358,23 @@
   },
   "discover": {
     "title": "Découvrir les événements",
-    "description": "Plongez dans le pouls des événements tribaux, soirées rave, événements de hacking, avant-premières de cinéma privées, et plus encore."
+    "description": "Plongez dans le pouls des événements tribaux, soirées rave, événements de hacking, avant-premières de cinéma privées, et plus encore.",
+    "location-filter": {
+      "title": "Filtrer par lieu",
+      "description": "Afficher les événements près de chez vous",
+      "filter-by-location": "Filtrer par lieu",
+      "nearby": "Dans un rayon de {radius} km",
+      "use-my-location": "Utiliser ma position",
+      "locating": "Localisation...",
+      "location-set": "Position définie",
+      "radius": "Rayon",
+      "clear-filter": "Supprimer le filtre",
+      "geolocation-not-supported": "La géolocalisation n'est pas supportée par votre navigateur",
+      "permission-denied": "Permission de localisation refusée. Veuillez l'activer dans les paramètres de votre navigateur.",
+      "position-unavailable": "Les informations de localisation ne sont pas disponibles",
+      "timeout": "La demande de localisation a expiré",
+      "unknown-error": "Une erreur inconnue s'est produite lors de la récupération de votre position"
+    }
   },
   "tickets": {
     "title": "Vos billets",

--- a/backend/list_events.go
+++ b/backend/list_events.go
@@ -12,9 +12,20 @@ import (
 func (s *ZenaoServer) ListEvents(ctx context.Context, req *connect.Request[zenaov1.ListEventsRequest]) (*connect.Response[zenaov1.ListEventsResponse], error) {
 	var evts []*zeni.Event
 	var infos []*zenaov1.EventInfo
+
+	// Extract location filter parameters
+	var locFilter *zeni.LocationFilter
+	if req.Msg.LocationFilter != nil {
+		locFilter = &zeni.LocationFilter{
+			Lat:      req.Msg.LocationFilter.Lat,
+			Lng:      req.Msg.LocationFilter.Lng,
+			RadiusKm: req.Msg.LocationFilter.RadiusKm,
+		}
+	}
+
 	if err := s.DB.TxWithSpan(ctx, "ListEvents", func(tx zeni.DB) error {
 		var err error
-		evts, err = tx.ListEvents(int(req.Msg.Limit), int(req.Msg.Offset), req.Msg.From, req.Msg.To, req.Msg.DiscoverableFilter)
+		evts, err = tx.ListEvents(int(req.Msg.Limit), int(req.Msg.Offset), req.Msg.From, req.Msg.To, req.Msg.DiscoverableFilter, locFilter)
 		if err != nil {
 			return err
 		}

--- a/backend/zenao/v1/zenao.pb.go
+++ b/backend/zenao/v1/zenao.pb.go
@@ -621,6 +621,7 @@ type ListEventsRequest struct {
 	From               int64                  `protobuf:"varint,3,opt,name=from,proto3" json:"from,omitempty"`                                                                                        // unix seconds
 	To                 int64                  `protobuf:"varint,4,opt,name=to,proto3" json:"to,omitempty"`                                                                                            // unix seconds
 	DiscoverableFilter DiscoverableFilter     `protobuf:"varint,5,opt,name=discoverable_filter,json=discoverableFilter,proto3,enum=zenao.v1.DiscoverableFilter" json:"discoverable_filter,omitempty"` // XXX: should we ensure events non discoverable are listed only if the user is an organizer?
+	LocationFilter     *LocationFilter        `protobuf:"bytes,6,opt,name=location_filter,json=locationFilter,proto3" json:"location_filter,omitempty"`                                              // optional location filter
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -688,6 +689,54 @@ func (x *ListEventsRequest) GetDiscoverableFilter() DiscoverableFilter {
 		return x.DiscoverableFilter
 	}
 	return DiscoverableFilter_DISCOVERABLE_FILTER_UNSPECIFIED
+}
+
+func (x *ListEventsRequest) GetLocationFilter() *LocationFilter {
+	if x != nil {
+		return x.LocationFilter
+	}
+	return nil
+}
+
+// Filter events by geographical location
+type LocationFilter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Lat           float32                `protobuf:"fixed32,1,opt,name=lat,proto3" json:"lat,omitempty"`       // latitude of the center point
+	Lng           float32                `protobuf:"fixed32,2,opt,name=lng,proto3" json:"lng,omitempty"`       // longitude of the center point
+	RadiusKm      float32                `protobuf:"fixed32,3,opt,name=radius_km,json=radiusKm,proto3" json:"radius_km,omitempty"` // radius in kilometers
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LocationFilter) Reset() {
+	*x = LocationFilter{}
+}
+
+func (x *LocationFilter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LocationFilter) ProtoMessage() {}
+
+func (x *LocationFilter) GetLat() float32 {
+	if x != nil {
+		return x.Lat
+	}
+	return 0
+}
+
+func (x *LocationFilter) GetLng() float32 {
+	if x != nil {
+		return x.Lng
+	}
+	return 0
+}
+
+func (x *LocationFilter) GetRadiusKm() float32 {
+	if x != nil {
+		return x.RadiusKm
+	}
+	return 0
 }
 
 type ListEventsResponse struct {

--- a/backend/zeni/zeni.go
+++ b/backend/zeni/zeni.go
@@ -129,6 +129,13 @@ type Event struct {
 	Discoverable      bool
 }
 
+// LocationFilter is used to filter events by geographical location
+type LocationFilter struct {
+	Lat      float32 // latitude of the center point
+	Lng      float32 // longitude of the center point
+	RadiusKm float32 // radius in kilometers
+}
+
 type EventWithRoles struct {
 	Event *Event
 	Roles []string
@@ -283,7 +290,7 @@ type DB interface {
 	EditEvent(eventID string, organizersIDs []string, gatekeepersIDs []string, req *zenaov1.EditEventRequest) (*Event, error)
 	ValidatePassword(req *zenaov1.ValidatePasswordRequest) (bool, error)
 	GetEvent(eventID string) (*Event, error)
-	ListEvents(limit int, offset int, from int64, to int64, discoverable zenaov1.DiscoverableFilter) ([]*Event, error)
+	ListEvents(limit int, offset int, from int64, to int64, discoverable zenaov1.DiscoverableFilter, locationFilter *LocationFilter) ([]*Event, error)
 	ListEventsByUserRoles(userID string, roles []string, limit int, offset int, from int64, to int64, discoverable zenaov1.DiscoverableFilter) ([]*EventWithRoles, error)
 	CountCheckedIn(eventID string) (uint32, error)
 	Participate(eventID string, buyerID string, userID string, ticketSecret string, password string, needPassword bool) error

--- a/components/features/event/event-location-filter.tsx
+++ b/components/features/event/event-location-filter.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { MapPin, X, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/shadcn/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/shadcn/popover";
+import { LocationFilterParams } from "@/lib/queries/events-list";
+
+const RADIUS_OPTIONS = [
+  { value: "10", label: "10 km" },
+  { value: "25", label: "25 km" },
+  { value: "50", label: "50 km" },
+  { value: "100", label: "100 km" },
+  { value: "250", label: "250 km" },
+];
+
+const DEFAULT_RADIUS = 50;
+
+type EventLocationFilterProps = {
+  onFilterChange: (filter: LocationFilterParams | undefined) => void;
+  currentFilter?: LocationFilterParams;
+};
+
+export function EventLocationFilter({
+  onFilterChange,
+  currentFilter,
+}: EventLocationFilterProps) {
+  const t = useTranslations("discover.location-filter");
+  const [isLocating, setIsLocating] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [radius, setRadius] = useState<number>(
+    currentFilter?.radiusKm ?? DEFAULT_RADIUS,
+  );
+  const [userLocation, setUserLocation] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(
+    currentFilter ? { lat: currentFilter.lat, lng: currentFilter.lng } : null,
+  );
+
+  const requestLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setLocationError(t("geolocation-not-supported"));
+      return;
+    }
+
+    setIsLocating(true);
+    setLocationError(null);
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        setUserLocation({ lat: latitude, lng: longitude });
+        setIsLocating(false);
+        onFilterChange({
+          lat: latitude,
+          lng: longitude,
+          radiusKm: radius,
+        });
+      },
+      (error) => {
+        setIsLocating(false);
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            setLocationError(t("permission-denied"));
+            break;
+          case error.POSITION_UNAVAILABLE:
+            setLocationError(t("position-unavailable"));
+            break;
+          case error.TIMEOUT:
+            setLocationError(t("timeout"));
+            break;
+          default:
+            setLocationError(t("unknown-error"));
+        }
+      },
+      {
+        enableHighAccuracy: false,
+        timeout: 10000,
+        maximumAge: 600000, // Cache for 10 minutes
+      },
+    );
+  }, [onFilterChange, radius, t]);
+
+  const handleRadiusChange = useCallback(
+    (value: string) => {
+      const newRadius = parseInt(value, 10);
+      setRadius(newRadius);
+      if (userLocation) {
+        onFilterChange({
+          lat: userLocation.lat,
+          lng: userLocation.lng,
+          radiusKm: newRadius,
+        });
+      }
+    },
+    [userLocation, onFilterChange],
+  );
+
+  const clearFilter = useCallback(() => {
+    setUserLocation(null);
+    setLocationError(null);
+    onFilterChange(undefined);
+  }, [onFilterChange]);
+
+  const isFilterActive = userLocation !== null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant={isFilterActive ? "default" : "outline"}
+          size="sm"
+          className="gap-2"
+        >
+          <MapPin className="h-4 w-4" />
+          {isFilterActive ? t("nearby", { radius }) : t("filter-by-location")}
+          {isFilterActive && (
+            <span
+              role="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                clearFilter();
+              }}
+              className="ml-1 hover:bg-primary-foreground/20 rounded-full p-0.5"
+            >
+              <X className="h-3 w-3" />
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72" align="start">
+        <div className="flex flex-col gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">{t("title")}</h4>
+            <p className="text-sm text-muted-foreground">{t("description")}</p>
+          </div>
+
+          {locationError && (
+            <div className="text-sm text-destructive bg-destructive/10 p-2 rounded">
+              {locationError}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3">
+            {!userLocation ? (
+              <Button
+                onClick={requestLocation}
+                disabled={isLocating}
+                className="w-full"
+              >
+                {isLocating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t("locating")}
+                  </>
+                ) : (
+                  <>
+                    <MapPin className="mr-2 h-4 w-4" />
+                    {t("use-my-location")}
+                  </>
+                )}
+              </Button>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <MapPin className="h-4 w-4" />
+                  {t("location-set")}
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">{t("radius")}</label>
+                  <Select
+                    value={radius.toString()}
+                    onValueChange={handleRadiusChange}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {RADIUS_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button variant="outline" onClick={clearFilter} className="w-full">
+                  {t("clear-filter")}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Summary
Adds an optional location-based filter to the Discover page, allowing users to view events near their location.

## Motivation
Currently, all events are displayed together, which makes it difficult for users to find nearby events.
This feature improves discoverability while keeping the existing behavior unchanged by default.

## Scope
- The feature is **opt-in**
- Default Discover behavior remains unchanged
- No breaking API changes

## Implementation
- Added a “Filter by location” option on the Discover page
- Uses the browser Geolocation API **only after explicit user consent**
- Allows users to select a radius (10km, 25km, 50km, 100km, 250km)
- Filters only events that include geolocation data (`loc_kind = "geo"`)
- Users can change the radius or clear the filter at any time
- Added translations for the filter UI (EN / FR)

## Privacy
- Location access is requested only on user action
- No location data is stored or persisted

## How to Test
1. Open the Discover page
2. Click “Filter by location”
3. Allow browser location access
4. Select a radius
5. Verify only nearby events are displayed
6. Clear the filter to see all events again

## Related Issue
Closes #722
