### PR TITLE
fix(e2e): mock /api/files to remove Pinata dependency in tests

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -15,3 +15,10 @@
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
+
+beforeEach(() => {
+  cy.intercept("POST", "/api/files", {
+    statusCode: 200,
+    body: { uri: "ipfs://test" },
+  });
+});


### PR DESCRIPTION
## Summary

- Add a global `beforeEach` in `cypress/support/e2e.ts` that intercepts `POST /api/files` and returns `{ uri: "ipfs://test" }`
- Removes the Pinata network dependency from all e2e tests (event image, community avatar/banner)
- The backend only validates that `imageUri` is non-empty and a valid URI — no image fetch ever occurs

Closes #1044

## Test plan

- [x] CI e2e tests pass (the `create an event` test no longer fails with `TypeError: Failed to fetch` on Pinata timeout)
- [x] All downstream tests that depended on the created event no longer cascade-fail with `record not found`