### PR TITLE
fix(e2e): use href-based selector for scanner button

### DIFF
--- a/cypress/e2e/main.cy.ts
+++ b/cypress/e2e/main.cy.ts
@@ -399,7 +399,7 @@ describe("main", () => {
     cy.url().should("contain", "/participants");
 
     // Open ticket scanner
-    cy.get("button").contains("QR Code Scanner").click();
+    cy.get("a[href$='/scanner'] button").click();
     cy.url().should("contain", "/scanner");
 
     cy.wait(5000);


### PR DESCRIPTION
## Summary

- Replaces `cy.get("button").contains("QR Code Scanner")` with `cy.get("a[href$='/scanner'] button")` in the "unable to scan a ticket" test
- Fixes the CI e2e failure on main after merging #1035

## Root cause

The previous selector was fragile in two ways:

**Locale-dependent**: The button text varies by the browser's `Accept-Language` header (EN: "QR Code Scanner", FR: "Scanner QR Code"). Since commit `bd4bb88e`, the app uses cookie → `Accept-Language` → `en` fallback for locale detection. If the CI browser sends a non-English locale, the selector never matches.

**Timing-dependent**: During client-side navigation from the event dashboard general tab to `/participants`, the URL changes immediately (so `cy.url().should("contain", "/participants")` passes), but the old general tab content -- which contains a `w-full` primary button ("Save changes") -- can remain in the DOM while the new participants content loads. `cy.get("button").contains("QR Code Scanner")` then times out after 10s against this wrong button.

## Fix

Target the button via its parent Link's `href` attribute instead of its text content. The scanner button is always wrapped in `<Link href=".../scanner">`, making this selector unique, locale-agnostic, and resilient to navigation timing.

## Test plan

- [x] CI e2e "unable to scan a ticket" test passes