### PR TITLE
fix(community/portfolio): stop calling GetCommunityAdministrators for non-admin visitors

### DIFF
--- a/app/(general)/community/(general)/[id]/[tab]/portfolio.tsx
+++ b/app/(general)/community/(general)/[id]/[tab]/portfolio.tsx
@@ -51,20 +51,6 @@ export default function CommunityPortfolio({
   const { data: communityInfo } = useSuspenseQuery(
     communityInfoQuery(communityId),
   );
-  const { data: administrators } = useSuspenseQuery({
-    queryKey: ["communityAdmins", communityId],
-    queryFn: async () => {
-      const token = await getToken();
-      if (!token) throw new Error("invalid clerk token");
-      const res = await zenaoClient.getCommunityAdministrators(
-        { communityId },
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
-      return res.administrators;
-    },
-    initialData: [],
-  });
-
   const isAdmin = userRoles.includes("administrator");
 
   const { portfolio, ...otherDetails } = deserializeWithFrontMatter({
@@ -88,6 +74,11 @@ export default function CommunityPortfolio({
     const token = await getToken();
     if (!token) throw new Error("invalid clerk token");
 
+    const adminsRes = await zenaoClient.getCommunityAdministrators(
+      { communityId },
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
     const description = serializeWithFrontMatter<
       Omit<CommunityDetails, "description">
     >(otherDetails.description, {
@@ -99,7 +90,7 @@ export default function CommunityPortfolio({
     await editCommunity({
       ...communityInfo,
       communityId,
-      administrators,
+      administrators: adminsRes.administrators,
       token,
       description,
     });


### PR DESCRIPTION
## Summary

- `GetCommunityAdministrators` was called on every community portfolio page load, regardless of the visitor's role
- The backend returns an error for non-admins, which flooded Sentry with false positive errors (`[unknown] user is not administrator of the community`)
- Moved the call inside `onSave`, which is only reachable by admins

## Test plan

- [x] Visit `/community/[id]/portfolio` as a non-admin user: page loads without error
- [x] Visit `/community/[id]/portfolio` as an admin user: page loads without error, save action still works correctly

Closes #1057