### PR TITLE
fix(sentry): fix env guard precedence bug, unify noise filtering, and align config

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
 import { ClerkProvider } from "@clerk/nextjs";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
@@ -18,6 +17,7 @@ import { Footer } from "@/components/layout/navigation/footer";
 import PwaBottomBar from "@/components/layout/navigation/pwa-bottom-bar";
 import { ScreenContainerCentered } from "@/components/layout/screen-container";
 import { Button } from "@/components/shadcn/button";
+import { captureException } from "@/lib/report";
 
 const albertSans = Albert_Sans({
   variable: "--font-albert-sans",
@@ -32,9 +32,7 @@ export default function GlobalError({
   const contextNow = new Date();
 
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_ENV ?? "development" !== "development") {
-      Sentry.captureException(error);
-    }
+    captureException(error);
   }, [error]);
 
   return (

--- a/components/portfolio/portfolio-tab.tsx
+++ b/components/portfolio/portfolio-tab.tsx
@@ -3,7 +3,6 @@ import { Loader2, AudioWaveform } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState, useRef, memo } from "react";
 
-import { captureException } from "@sentry/nextjs";
 import PortfolioPreviewDialog from "../dialogs/portfolio-preview-dialog";
 import PortfolioUploadVideoDialog from "../dialogs/portfolio-upload-video-dialog";
 import { Web3Image } from "../widgets/images/web3-image";
@@ -21,6 +20,7 @@ import { cn } from "@/lib/tailwind";
 import { PortfolioItem, PortfolioUploadVideoSchemaType } from "@/types/schemas";
 import { useToast } from "@/hooks/use-toast";
 import { uploadFile } from "@/lib/files";
+import { captureException } from "@/lib/report";
 
 const MemoizedVideoPreview = memo(({ uri }: { uri: string }) => (
   <MarkdownPreview

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,7 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { APP_ENV, IS_DEV, tracesSampleRate } from "@/lib/env";
+import { APP_ENV, tracesSampleRate } from "@/lib/env";
 
 // Single source of truth for client-side network blips (no connectivity, ad-blocker,
 // brief API downtime) that we cannot act on. Covers Chrome/Edge, Safari, Firefox and
@@ -48,8 +48,7 @@ function isNetworkError(error: unknown): boolean {
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // No-op locally (and whenever the DSN is missing) instead of relying on an unset DSN.
-  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN && !IS_DEV,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   environment: APP_ENV,
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,23 +3,76 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { APP_ENV, IS_DEV, tracesSampleRate } from "@/lib/env";
+
+// Single source of truth for client-side network blips (no connectivity, ad-blocker,
+// brief API downtime) that we cannot act on. Covers Chrome/Edge, Safari, Firefox and
+// React Native. Used both for `ignoreErrors` (direct errors) and `isNetworkError`
+// (wrapped errors, e.g. ConnectError wrapping a TypeError: Failed to fetch).
+const NETWORK_ERROR_PATTERNS = [
+  "Failed to fetch",
+  "Load failed",
+  "Network request failed",
+  "NetworkError when attempting to fetch resource",
+];
+
+// Browser noise that is never actionable on our side.
+const BROWSER_NOISE_PATTERNS = [
+  // Benign ResizeObserver notifications fired by some browsers.
+  "ResizeObserver loop limit exceeded",
+  "ResizeObserver loop completed with undelivered notifications",
+];
+
+// Walks the `error.cause` chain (bounded depth) so wrapped network errors are caught.
+function isNetworkError(error: unknown): boolean {
+  let current = error;
+
+  for (let depth = 0; current && depth < 5; depth++) {
+    const message =
+      typeof current === "string"
+        ? current
+        : current instanceof Error
+          ? current.message
+          : "";
+
+    if (NETWORK_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
+      return true;
+    }
+
+    current = current instanceof Error ? current.cause : undefined;
+  }
+
+  return false;
+}
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  environment: process.env.NEXT_PUBLIC_ENV ?? "development",
+  // No-op locally (and whenever the DSN is missing) instead of relying on an unset DSN.
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN && !IS_DEV,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.7,
+  environment: APP_ENV,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  tracesSampleRate,
+
   debug: false,
+
+  // Filters direct network errors by message. beforeSend below covers wrapped errors.
+  ignoreErrors: [...NETWORK_ERROR_PATTERNS, ...BROWSER_NOISE_PATTERNS],
 
   integrations: [
     Sentry.feedbackIntegration({
       autoInject: false,
     }),
   ],
+
+  beforeSend(event, hint) {
+    if (isNetworkError(hint?.originalException)) {
+      return null;
+    }
+
+    return event;
+  },
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -23,6 +23,47 @@ const BROWSER_NOISE_PATTERNS = [
   "ResizeObserver loop completed with undelivered notifications",
 ];
 
+const EXTENSION_URL_PREFIXES = [
+  "chrome-extension://",
+  "moz-extension://",
+  "safari-extension://",
+  "safari-web-extension://",
+];
+
+// Drops errors originating from browser extensions. Extensions inject into every
+// page and produce noise we cannot act on. Signal: a stack frame whose file is
+// served from an extension URL.
+function isBrowserExtensionError(event: Sentry.ErrorEvent): boolean {
+  const frames =
+    event.exception?.values?.flatMap((v) => v.stacktrace?.frames ?? []) ?? [];
+  return frames.some((f) =>
+    EXTENSION_URL_PREFIXES.some((p) => f.filename?.startsWith(p)),
+  );
+}
+
+// Drops JSON-RPC / EIP-1193 provider errors. Wallet extensions (Keplr, MetaMask…)
+// inject into every page and reject with these codes when several wallets clash
+// (e.g. `{ code: -32603, message: "Internal JSON-RPC error." }`). We ship no web3
+// code, so any such rejection is third-party extension noise we cannot act on.
+// A ConnectError uses gRPC codes (1-16), never these, so there is no false positive.
+function isWalletProviderError(originalException: unknown): boolean {
+  if (
+    !originalException ||
+    typeof originalException !== "object" ||
+    originalException instanceof Error
+  ) {
+    return false;
+  }
+  const code = (originalException as { code?: unknown }).code;
+  if (typeof code !== "number") {
+    return false;
+  }
+  return (
+    (code >= -32768 && code <= -32000) || // JSON-RPC 2.0 reserved (incl. -32603)
+    [4001, 4100, 4200, 4900, 4901].includes(code) // EIP-1193 provider errors
+  );
+}
+
 // Walks the `error.cause` chain (bounded depth) so wrapped network errors are caught.
 function isNetworkError(error: unknown): boolean {
   let current = error;
@@ -67,6 +108,14 @@ Sentry.init({
 
   beforeSend(event, hint) {
     if (isNetworkError(hint?.originalException)) {
+      return null;
+    }
+
+    if (isBrowserExtensionError(event)) {
+      return null;
+    }
+
+    if (isWalletProviderError(hint?.originalException)) {
       return null;
     }
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -7,8 +7,11 @@ import { APP_ENV, tracesSampleRate } from "@/lib/env";
 
 // Single source of truth for client-side network blips (no connectivity, ad-blocker,
 // brief API downtime) that we cannot act on. Covers Chrome/Edge, Safari, Firefox and
-// React Native. Used both for `ignoreErrors` (direct errors) and `isNetworkError`
-// (wrapped errors, e.g. ConnectError wrapping a TypeError: Failed to fetch).
+// React Native. Browsers emit these as the *entire* error message; connect-es re-wraps
+// them as `[code] <message>` (e.g. `[unavailable] Failed to fetch`) and keeps the
+// original error as `.cause`. `isNetworkError` matches a pattern exactly or behind that
+// prefix, so a genuine app error that merely *contains* the words (e.g. "Image Load
+// failed", "Failed to fetch user config") is still reported.
 const NETWORK_ERROR_PATTERNS = [
   "Failed to fetch",
   "Load failed",
@@ -64,6 +67,15 @@ function isWalletProviderError(originalException: unknown): boolean {
   );
 }
 
+// True when `message` is exactly a network blip, or a connect-es-wrapped one
+// (`[code] <message>`). Anchored rather than substring so unrelated app errors that
+// merely contain the words are not swallowed.
+function matchesNetworkPattern(message: string): boolean {
+  return NETWORK_ERROR_PATTERNS.some(
+    (pattern) => message === pattern || message.endsWith(`] ${pattern}`),
+  );
+}
+
 // Walks the `error.cause` chain (bounded depth) so wrapped network errors are caught.
 function isNetworkError(error: unknown): boolean {
   let current = error;
@@ -76,7 +88,7 @@ function isNetworkError(error: unknown): boolean {
           ? current.message
           : "";
 
-    if (NETWORK_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
+    if (matchesNetworkPattern(message)) {
       return true;
     }
 
@@ -97,8 +109,9 @@ Sentry.init({
 
   debug: false,
 
-  // Filters direct network errors by message. beforeSend below covers wrapped errors.
-  ignoreErrors: [...NETWORK_ERROR_PATTERNS, ...BROWSER_NOISE_PATTERNS],
+  // Network errors (direct *and* wrapped) are handled by the anchored isNetworkError
+  // check in beforeSend. Here we only drop browser noise like ResizeObserver.
+  ignoreErrors: BROWSER_NOISE_PATTERNS,
 
   integrations: [
     Sentry.feedbackIntegration({

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,16 @@
+// Centralised environment detection. Kept in one place so the parsing logic
+// (which is easy to get wrong with `??`/`!==` precedence) lives only here.
+
+// Only NEXT_PUBLIC_* vars are exposed to the browser, so NEXT_PUBLIC_ENV is the
+// canonical environment name across client, server and edge runtimes.
+// Fall back to NODE_ENV so a deploy that forgets to set NEXT_PUBLIC_ENV still
+// behaves like production (Sentry enabled) instead of silently going dark.
+export const APP_ENV =
+  process.env.NEXT_PUBLIC_ENV ??
+  (process.env.NODE_ENV === "production" ? "production" : "development");
+
+export const IS_DEV = APP_ENV === "development";
+export const IS_PROD = APP_ENV === "production";
+
+// Trace sampling: full traces locally/preview, low in production to control quota.
+export const tracesSampleRate = IS_PROD ? 0.1 : 1.0;

--- a/lib/report.ts
+++ b/lib/report.ts
@@ -1,8 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
+import { IS_DEV } from "@/lib/env";
 
 export const captureException = (error: unknown) => {
   console.error("Error captured:", error);
-  if (process.env.NEXT_PUBLIC_ENV ?? "development" !== "development") {
+  if (!IS_DEV) {
     Sentry.captureException(error, {
       fingerprint: [
         "{{ default }}",

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,14 +4,16 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { tracesSampleRate } from "@/lib/env";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  environment: process.env.VERCEL_ENV ?? "development",
+  environment:
+    process.env.NEXT_PUBLIC_ENV ?? process.env.VERCEL_ENV ?? "development",
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.7,
+  // Sampled lower in production to control quota; see lib/env.ts.
+  tracesSampleRate,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,14 +3,16 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { tracesSampleRate } from "@/lib/env";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  environment: process.env.VERCEL_ENV ?? "development",
+  environment:
+    process.env.NEXT_PUBLIC_ENV ?? process.env.VERCEL_ENV ?? "development",
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.7,
+  // Sampled lower in production to control quota; see lib/env.ts.
+  tracesSampleRate,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
Fixes #1059

## Summary

- **Operator precedence bug fixed**: `NEXT_PUBLIC_ENV ?? "development" !== "development"` was parsed as `env ?? false` — causing Sentry to capture exceptions in dev when `NEXT_PUBLIC_ENV` was explicitly set. Fixed in `lib/report.ts` and `app/global-error.tsx`.
- **Cause-chain traversal**: `isNetworkError` now walks `error.cause` (depth 5), so wrapped errors (e.g. `ConnectError` over `TypeError: Failed to fetch`) are actually filtered as the comment promised.
- **Anchored network-error matching**: replaced `.includes()` with an anchored `matchesNetworkPattern` helper — a message must be exactly the pattern, or end with `] <pattern>` (connect-es format: `[code] <message>`). App errors whose text merely contains the words (e.g. `"Image Load failed"`, `"Failed to fetch user config"`) now reach Sentry. `NETWORK_ERROR_PATTERNS` is removed from `ignoreErrors` (redundant and riskier as substring); `beforeSend` handles both direct and wrapped network errors.
- **Sentry active in all envs**: `enabled: !!DSN` — Sentry runs in local dev when the DSN is present, so the `development` environment in Sentry is actually useful during fix sprints.
- **Env-aware sampling**: `tracesSampleRate` is 0.1 in production and 1.0 elsewhere across all three runtimes (client, server, edge).
- **Consistent capture path**: `global-error.tsx` and `portfolio-tab.tsx` now use `captureException` from `@/lib/report` instead of calling `@sentry/nextjs` directly (which bypassed the env guard and fingerprinting).
- **New `lib/env.ts`**: single source of truth for `APP_ENV`, `IS_DEV`, `IS_PROD`, `tracesSampleRate`. Falls back to `NODE_ENV` so a deployment that forgets `NEXT_PUBLIC_ENV` behaves like production (Sentry stays enabled) instead of going dark silently.
- **Wallet extension noise filtered**: `isWalletProviderError` drops plain-object rejections with JSON-RPC 2.0 reserved codes (`-32768..-32000`, incl. `-32603 "Internal JSON-RPC error"`) and EIP-1193 codes (`4001`, etc.). Wallet extensions (Keplr, MetaMask) inject into every page and reject with these codes when multiple wallets clash — we ship no web3 code so they are unactionable. A `ConnectError` uses gRPC codes (1-16), never these, so there is no false positive. The `extension|inject` regex previously in `isBrowserExtensionError` (too broad, did not catch this case) was removed.

## Test plan

- [x] App starts locally without errors (`make dev`)
- [x] `tsc --noEmit` exits 0
- [x] No new lint errors introduced
- [x] In local dev with DSN set, Sentry initializes and events appear under the `development` environment in the Sentry dashboard
- [x] Deliberately wrapped network error (`ConnectError` wrapping `TypeError: Failed to fetch`) does not appear in Sentry
- [x] App error whose message contains a network-blip substring (e.g. `"Image Load failed"`) does appear in Sentry (anchored matching, not substring)
- [x] `grep -rn "captureException" --include=*.ts --include=*.tsx | grep "@sentry/nextjs"` returns empty (no direct bypass)
- [x] Sentry issue 554 (`UnhandledRejection: Object captured as promise rejection with keys: code, message` — Keplr wallet conflict) no longer recurs after deploying