### PR TITLE
feat(header): improve right side of main header and dashboard header

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -817,6 +817,7 @@
       "create-team": "Create a team",
       "profile": "Profile",
       "language": "Language",
+      "theme": "Theme",
       "sign-out": "Sign out"
     },
     "createTeam": {

--- a/app/i18n/messages/es.json
+++ b/app/i18n/messages/es.json
@@ -817,6 +817,7 @@
       "create-team": "Crear un equipo",
       "profile": "Perfil",
       "language": "Idioma",
+      "theme": "Tema",
       "sign-out": "Cerrar sesión"
     },
     "createTeam": {

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -817,6 +817,7 @@
       "create-team": "Créer une équipe",
       "profile": "Profil",
       "language": "Langue",
+      "theme": "Thème",
       "sign-out": "Se déconnecter"
     },
     "createTeam": {

--- a/components/features/dashboard/header.tsx
+++ b/components/features/dashboard/header.tsx
@@ -7,6 +7,8 @@ import { UserMenu } from "../user/user-menu";
 import { Separator } from "@/components/shadcn/separator";
 import { SidebarTrigger } from "@/components/shadcn/sidebar";
 import { ToggleThemeButton } from "@/components/widgets/buttons/toggle-theme-button";
+import { LocaleSwitcher } from "@/components/layout/navigation/locale-switcher";
+import QuickCreateMenu from "@/components/layout/navigation/header/quick-create-menu";
 import { cn } from "@/lib/tailwind";
 import { NavbarStyle } from "@/lib/preferences/preferences";
 import { Skeleton } from "@/components/shadcn/skeleton";
@@ -21,7 +23,7 @@ export default function DashboardHeader({ navbarStyle }: DashboardHeaderProps) {
     <header
       data-navbar-style={navbarStyle}
       className={cn(
-        "flex py-2 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:py-2",
+        "flex py-4 md:py-2 shrink-0 items-center gap-2 md:border-b transition-[width,height] ease-linear md:group-has-data-[collapsible=icon]/sidebar-wrapper:py-2",
         // Handle sticky navbar style with conditional classes so blur, background, z-index, and rounded corners remain consistent across all SidebarVariant layouts.
         "data-[navbar-style=sticky]:bg-background/50 data-[navbar-style=sticky]:sticky data-[navbar-style=sticky]:top-0 data-[navbar-style=sticky]:z-50 data-[navbar-style=sticky]:overflow-hidden data-[navbar-style=sticky]:rounded-t-[inherit] data-[navbar-style=sticky]:backdrop-blur-md",
       )}
@@ -34,7 +36,9 @@ export default function DashboardHeader({ navbarStyle }: DashboardHeaderProps) {
             className="mx-2 data-[orientation=vertical]:h-4"
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-4">
+          <QuickCreateMenu />
+          <LocaleSwitcher />
           <ToggleThemeButton />
           <Suspense fallback={<Skeleton className="h-8 w-8 rounded-full" />}>
             <DashboardUserMenu />

--- a/components/features/user/user-menu.tsx
+++ b/components/features/user/user-menu.tsx
@@ -2,17 +2,22 @@
 
 import {
   Check,
+  ChevronDown,
   CircleUserRound,
   Eye,
+  Globe,
   LayoutDashboard,
   LogOut,
+  Moon,
   Plus,
+  Sun,
 } from "lucide-react";
 import { SignOutButton, useAuth } from "@clerk/nextjs";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
-import { ReactNode } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { ReactNode, useState } from "react";
+import { useTheme } from "next-themes";
 import { UserAvatar } from "./user";
 import { CreateTeamDialog } from "@/components/dialogs/create-team-dialog";
 import {
@@ -23,11 +28,19 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/shadcn/dropdown-menu";
+import { cn } from "@/lib/tailwind";
 import { useAccountSwitcher } from "@/hooks/use-account-switcher";
 import { profileOptions } from "@/lib/queries/profile";
 import { userInfoOptions } from "@/lib/queries/user";
 import RoleBasedViewMode from "@/components/widgets/permissions/view-mode";
 import { planSchema } from "@/types/schemas";
+import {
+  type Locale,
+  locales,
+  localeNames,
+  localeFlags,
+} from "@/app/i18n/config";
+import { useLocaleChange } from "@/hooks/use-locale-change";
 
 export type UserMenuVariant = "dashboard" | "customer";
 
@@ -76,9 +89,24 @@ export function UserMenu({
 
   const currentAccountId = activeAccount?.id ?? userId;
 
+  const [isLangExpanded, setIsLangExpanded] = useState(false);
+  const [isThemeExpanded, setIsThemeExpanded] = useState(false);
+
+  const { theme, setTheme } = useTheme();
+  const tTheme = useTranslations("components.toggle-theme-button");
+  const currentLocale = useLocale() as Locale;
+  const { isPending: isLocalePending, handleLocaleChange } = useLocaleChange();
+
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsLangExpanded(false);
+            setIsThemeExpanded(false);
+          }
+        }}
+      >
         <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
         <DropdownMenuContent
           className="min-w-56 rounded-lg"
@@ -176,8 +204,6 @@ export function UserMenu({
             </DropdownMenuItem>
           </DropdownMenuGroup>
 
-          <DropdownMenuSeparator />
-
           {/* View switch */}
           {variant === "dashboard" ? (
             <DropdownMenuItem asChild className="cursor-pointer">
@@ -193,6 +219,81 @@ export function UserMenu({
                 {tNav("dashboard-view")}
               </Link>
             </DropdownMenuItem>
+          )}
+
+          <DropdownMenuSeparator />
+
+          {/* Mobile-only: language and theme (customer variant only, dashboard header always shows these) */}
+          {variant === "customer" && (
+            <>
+              <DropdownMenuItem
+                className="sm:hidden cursor-pointer"
+                onSelect={(e) => e.preventDefault()}
+                onClick={() => {
+                  setIsLangExpanded((v) => !v);
+                  setIsThemeExpanded(false);
+                }}
+              >
+                <Globe className="h-4 w-4" />
+                {t("language")}
+                <ChevronDown
+                  className={cn(
+                    "ml-auto h-4 w-4 transition-transform",
+                    isLangExpanded && "rotate-180",
+                  )}
+                />
+              </DropdownMenuItem>
+              {isLangExpanded &&
+                locales.map((locale) => (
+                  <DropdownMenuItem
+                    key={locale}
+                    className="sm:hidden pl-8 cursor-pointer"
+                    disabled={isLocalePending}
+                    onClick={() => handleLocaleChange(locale)}
+                  >
+                    <span>{localeFlags[locale]}</span>
+                    {localeNames[locale]}
+                    {locale === currentLocale && (
+                      <Check className="ml-auto h-4 w-4" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+
+              <DropdownMenuItem
+                className="sm:hidden cursor-pointer"
+                onSelect={(e) => e.preventDefault()}
+                onClick={() => {
+                  setIsThemeExpanded((v) => !v);
+                  setIsLangExpanded(false);
+                }}
+              >
+                <Sun className="h-4 w-4 rotate-0 scale-100 dark:-rotate-90 dark:scale-0" />
+                <Moon className="absolute h-4 w-4 rotate-90 scale-0 dark:rotate-0 dark:scale-100" />
+                {t("theme")}
+                <ChevronDown
+                  className={cn(
+                    "ml-auto h-4 w-4 transition-transform",
+                    isThemeExpanded && "rotate-180",
+                  )}
+                />
+              </DropdownMenuItem>
+              {isThemeExpanded && (
+                <>
+                  {(["light", "dark", "system"] as const).map((t) => (
+                    <DropdownMenuItem
+                      key={t}
+                      className="sm:hidden pl-8 cursor-pointer"
+                      onClick={() => setTheme(t)}
+                    >
+                      {tTheme(`${t}-option`)}
+                      {theme === t && <Check className="ml-auto h-4 w-4" />}
+                    </DropdownMenuItem>
+                  ))}
+                </>
+              )}
+
+              <DropdownMenuSeparator className="sm:hidden" />
+            </>
           )}
 
           {/* Sign out */}

--- a/components/layout/navigation/footer.tsx
+++ b/components/layout/navigation/footer.tsx
@@ -8,7 +8,6 @@ import Link from "next/link";
 import Text from "@/components/widgets/texts/text";
 import { Button } from "@/components/shadcn/button";
 import { Discord } from "@/components/widgets/icons";
-import { LocaleSwitcher } from "@/components/layout/navigation/locale-switcher";
 
 export const Footer = () => {
   const t = useTranslations("navigation");
@@ -55,7 +54,6 @@ export const Footer = () => {
         <Link href="https://discord.gg/TkpJgp9zjK" target="_blank">
           <Discord className="text-secondary-color hover:text-primary-color h-5 w-5" />
         </Link>
-        <LocaleSwitcher />
       </div>
     </footer>
   );

--- a/components/layout/navigation/header/index.tsx
+++ b/components/layout/navigation/header/index.tsx
@@ -183,7 +183,7 @@ export function Header() {
               alt={tImages("zenao-logo")}
               width={28}
               height={28}
-              className="max-[450px]:w-6 max-[450px]:h-6"
+              className=""
               priority
             />
             <Text className="max-md:hidden font-extrabold">{t("zenao")}</Text>
@@ -195,12 +195,10 @@ export function Header() {
         </div>
       </div>
 
-      <div className="flex gap-2 items-center">
+      <div className="flex gap-4 items-center">
         <QuickCreateMenu />
-        <div className="max-md:hidden">
+        <div className="hidden sm:flex gap-4 items-center">
           <LocaleSwitcher />
-        </div>
-        <div className="max-md:hidden">
           <ToggleThemeButton />
         </div>
         <Suspense fallback={<UserAvatarSignedButtonSkeleton />}>

--- a/components/layout/navigation/locale-switcher.tsx
+++ b/components/layout/navigation/locale-switcher.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useLocale, useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
-import { useTransition } from "react";
 import { Globe } from "lucide-react";
 import { Button } from "@/components/shadcn/button";
 import {
@@ -17,20 +15,12 @@ import {
   localeNames,
   localeFlags,
 } from "@/app/i18n/config";
-import { setLocale } from "@/app/i18n/set-locale";
+import { useLocaleChange } from "@/hooks/use-locale-change";
 
 export function LocaleSwitcher() {
   const currentLocale = useLocale() as Locale;
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
   const t = useTranslations("a11y");
-
-  function handleLocaleChange(locale: Locale) {
-    startTransition(async () => {
-      await setLocale(locale);
-      router.refresh();
-    });
-  }
+  const { isPending, handleLocaleChange } = useLocaleChange();
 
   return (
     <DropdownMenu>
@@ -38,11 +28,11 @@ export function LocaleSwitcher() {
         <Button
           variant="ghost"
           size="icon"
-          className="h-9 w-9"
+          className="h-auto w-auto p-0 text-secondary-color hover:text-primary-color hover:bg-transparent [&_svg]:size-5"
           disabled={isPending}
           aria-label={t("switch-language")}
         >
-          <Globe className="h-[1.2rem] w-[1.2rem] text-secondary-color hover:text-primary-color" />
+          <Globe />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/components/shadcn/sidebar.tsx
+++ b/components/shadcn/sidebar.tsx
@@ -213,7 +213,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className="w-[--sidebar-width] bg-sidebar p-2 text-sidebar-foreground [&>button]:hidden"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,

--- a/components/widgets/buttons/toggle-theme-button.tsx
+++ b/components/widgets/buttons/toggle-theme-button.tsx
@@ -25,9 +25,13 @@ export const ToggleThemeButton: React.FC = () => {
         asChild
         aria-label={t("dropdown-trigger-aria-label")}
       >
-        <Button variant="outline" size="icon" className="focus-visible:ring-0">
-          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="focus-visible:ring-0 h-auto w-auto p-0 text-secondary-color hover:text-primary-color hover:bg-transparent [&_svg]:size-5"
+        >
+          <Sun className="w-5 h-5 text-inherit rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute w-5 h-5 text-inherit rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">{t("toggle-theme-label")}</span>
         </Button>
       </DropdownMenuTrigger>

--- a/hooks/use-locale-change.ts
+++ b/hooks/use-locale-change.ts
@@ -1,0 +1,18 @@
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { type Locale } from "@/app/i18n/config";
+import { setLocale } from "@/app/i18n/set-locale";
+
+export function useLocaleChange() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleLocaleChange(locale: Locale) {
+    startTransition(async () => {
+      await setLocale(locale);
+      router.refresh();
+    });
+  }
+
+  return { isPending, handleLocaleChange };
+}


### PR DESCRIPTION
## Summary

- **Unified header controls styling**: `LocaleSwitcher` and `ToggleThemeButton` now share a consistent ghost style (no background, secondary color, 20px icon size) aligned with the rest of the header icon buttons
- **Dashboard header right side**: added `QuickCreateMenu`, `LocaleSwitcher`, and `ToggleThemeButton` to the dashboard header, matching the main header's right-side controls
- **Mobile UX**: on small screens, locale and theme controls are hidden from the header but accessible via inline expand/collapse sections inside the customer `UserMenu` dropdown
- **Locale logic extracted**: new `useLocaleChange` hook centralizes the `setLocale` + `router.refresh()` pattern, removing duplication between `LocaleSwitcher` and the user menu
- **Footer cleanup**: removed `LocaleSwitcher` from the footer since it is now surfaced in the header (and mobile menu)
- **Mobile sidebar**: fixed missing padding (`p-0` to `p-2`)

## Changes

- `hooks/use-locale-change.ts` - new hook extracting locale change logic
- `components/layout/navigation/locale-switcher.tsx` - uses new hook, updated styling
- `components/widgets/buttons/toggle-theme-button.tsx` - updated styling to match
- `components/layout/navigation/header/index.tsx` - grouped locale/theme controls, hidden on mobile
- `components/features/dashboard/header.tsx` - added QuickCreateMenu, LocaleSwitcher, ToggleThemeButton
- `components/features/user/user-menu.tsx` - added mobile-only inline language and theme pickers (customer variant only)
- `components/layout/navigation/footer.tsx` - removed LocaleSwitcher
- `components/shadcn/sidebar.tsx` - fixed mobile sidebar padding
- `app/i18n/messages/{en,fr,es}.json` - added `userMenu.theme` translation key

## Test plan

- [x] Main header: locale switcher and theme toggle render correctly on desktop
- [x] Main header: locale switcher and theme toggle are hidden on mobile
- [x] Dashboard header: QuickCreateMenu, locale switcher, and theme toggle appear on the right side
- [x] Mobile: opening the user menu (customer) shows inline language and theme pickers
- [x] Mobile: selecting a language or theme works correctly from the user menu
- [x] Language and theme pickers collapse when switching to the other one
- [x] Footer no longer shows a locale switcher
- [x] Mobile sidebar has correct padding