### PR TITLE
fix(feed): exclude comments from main social feed

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -582,6 +582,7 @@
       "message-placeholder-sm": "Say something...",
       "message-placeholder-lg": "Don't be shy, say something!",
       "toast-post-creation-success": "Post created !",
+      "toast-comment-creation-success": "Comment created !",
       "toast-post-creation-error": "Error on creating post !",
       "toast-post-edit-error": "Error on editing post !",
       "comment-restricted-to-members": "You must be a member to submit a comment.",

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -582,6 +582,7 @@
       "message-placeholder-sm": "Dites quelque chose...",
       "message-placeholder-lg": "Ne soyez pas timide, dites quelque chose !",
       "toast-post-creation-success": "Publication créée !",
+      "toast-comment-creation-success": "Commentaire créé !",
       "toast-post-creation-error": "Erreur lors de la création de la publication !",
       "toast-post-edit-error": "Erreur lors de la modification de la publication !",
       "comment-restricted-to-members": "Vous devez être membre pour soumettre un commentaire.",

--- a/backend/gzdb/db_feeds.go
+++ b/backend/gzdb/db_feeds.go
@@ -268,6 +268,7 @@ func (g *gormZenaoDB) GetPostsByFeedID(feedID string, limit int, offset int, tag
 		Preload("Reactions").
 		Preload("Tags").
 		Where("feed_id = ?", feedIDUint).
+		Where("parent_uri = ?", "").
 		Order("pinned_at IS NOT NULL DESC, pinned_at DESC, id DESC")
 
 	if len(tags) > 0 {

--- a/components/social-feed/forms/post-comment-form.tsx
+++ b/components/social-feed/forms/post-comment-form.tsx
@@ -67,7 +67,7 @@ export default function PostCommentForm({
       });
 
       toast({
-        title: t("toast-post-creation-success"),
+        title: t("toast-comment-creation-success"),
       });
 
       form.resetField("content", { defaultValue: "" });


### PR DESCRIPTION
## Summary

- Comments were appearing alongside root posts in the event and community social feeds
- Root cause: `GetPostsByFeedID` queried all posts without filtering on `parent_uri`, so comments (which have a non-empty `parent_uri`) were included
- Fix: add `.Where("parent_uri = ?", "")` to the GORM query so only root posts are returned

## Test plan

- [x] Go to an event or community with posts that have comments
- [x] Verify that the feed only shows root posts (no comments in the list)
- [x] Open a post detail page and verify comments still appear there
- [x] Verify pagination still works correctly
- [x] Verify pinned posts still appear at the top

Closes #1062