### PR TITLE
fix(post-page): display event/community info and tabs

### DIFF
--- a/app/(general)/feed/[orgType]/[orgId]/post/[postId]/page.tsx
+++ b/app/(general)/feed/[orgType]/[orgId]/post/[postId]/page.tsx
@@ -5,10 +5,16 @@ import { getQueryClient } from "@/lib/get-query-client";
 import { OrgType } from "@/lib/organization";
 import { ScreenContainer } from "@/components/layout/screen-container";
 import { feedPost } from "@/lib/queries/social-feed";
+import { eventOptions } from "@/lib/queries/event";
+import { communityInfo } from "@/lib/queries/community";
+import { imageHeight, imageWidth } from "@/components/features/event/constants";
 
 interface PageProps {
   params: Promise<{ orgType: string; orgId: string; postId: string }>;
 }
+
+const COMMUNITY_BANNER_FALLBACK =
+  "ipfs://bafybeib2gyk2yagrcdrnhpgbaj6an6ghk2liwx2mshhoa6d54y2mheny24";
 
 export default async function SocialFeedPostPage({ params }: PageProps) {
   const queryClient = getQueryClient();
@@ -25,11 +31,44 @@ export default async function SocialFeedPostPage({ params }: PageProps) {
     notFound();
   }
 
+  let backgroundSrc = "";
+  let backgroundWidth = 0;
+  let backgroundHeight = 0;
+
+  if (orgType === "event") {
+    try {
+      const eventData = await queryClient.fetchQuery(eventOptions(orgId));
+      backgroundSrc = eventData.imageUri;
+      backgroundWidth = imageWidth;
+      backgroundHeight = imageHeight;
+    } catch {
+      notFound();
+    }
+  } else {
+    try {
+      const communityData = await queryClient.fetchQuery(communityInfo(orgId));
+      backgroundSrc =
+        communityData.bannerUri.length > 0
+          ? communityData.bannerUri
+          : COMMUNITY_BANNER_FALLBACK;
+      backgroundWidth = 3840;
+      backgroundHeight = 720;
+    } catch {
+      notFound();
+    }
+  }
+
   const feedId = `${orgType}:${orgId}:main`;
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <ScreenContainer>
+      <ScreenContainer
+        background={{
+          src: backgroundSrc,
+          width: backgroundWidth,
+          height: backgroundHeight,
+        }}
+      >
         <PostInfo
           orgType={orgType as OrgType}
           orgId={orgId}

--- a/app/(general)/feed/[orgType]/[orgId]/post/[postId]/post-info.tsx
+++ b/app/(general)/feed/[orgType]/[orgId]/post/[postId]/post-info.tsx
@@ -5,8 +5,11 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { userInfoOptions } from "@/lib/queries/user";
 import { feedPost } from "@/lib/queries/social-feed";
+import { eventOptions } from "@/lib/queries/event";
 import { OrgType } from "@/lib/organization";
 import useFeedPostEditHandler from "@/hooks/use-feed-post-edit-handler";
 import useFeedPostReactionHandler from "@/hooks/use-feed-post-reaction-handler";
@@ -22,6 +25,10 @@ import Heading from "@/components/widgets/texts/heading";
 import CommunityPostInfo from "@/components/features/community/community-post-info";
 import EventPostInfo from "@/components/features/event/event-post-info";
 import PostCommentForm from "@/components/social-feed/forms/post-comment-form";
+import { Tabs, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
+import { Separator } from "@/components/shadcn/separator";
+import { EventInfoLayout } from "@/app/(general)/event/[id]/(general)/event-info-layout";
+import CommunityInfoLayout from "@/app/(general)/community/(general)/[id]/community-info-layout";
 
 interface PostInfoProps {
   orgType: OrgType;
@@ -36,31 +43,133 @@ export default function PostInfo({
   postId,
   feedId,
 }: PostInfoProps) {
+  if (orgType === "event") {
+    return <EventPostPage eventId={orgId} postId={postId} feedId={feedId} />;
+  }
+  return (
+    <CommunityPostPage communityId={orgId} postId={postId} feedId={feedId} />
+  );
+}
+
+function EventPostTabsNav({ eventId }: { eventId: string }) {
+  const t = useTranslations("event");
+  return (
+    <Tabs value="feed" className="w-full min-h-0">
+      <TabsList className="flex w-full bg-transparent p-0 m-0 overflow-auto justify-start">
+        <Link href={`/event/${eventId}`} scroll={false}>
+          <TabsTrigger
+            value="description"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("about-event")}
+          </TabsTrigger>
+        </Link>
+        <Link href={`/event/${eventId}/feed`} scroll={false}>
+          <TabsTrigger
+            value="feed"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("discussion")}
+          </TabsTrigger>
+        </Link>
+        <Link href={`/event/${eventId}/votes`} scroll={false}>
+          <TabsTrigger
+            value="votes"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("votes")}
+          </TabsTrigger>
+        </Link>
+      </TabsList>
+      <Separator className="mb-3" />
+    </Tabs>
+  );
+}
+
+function CommunityPostTabsNav({ communityId }: { communityId: string }) {
+  const t = useTranslations("community");
+  return (
+    <Tabs value="chat" className="w-full min-h-0">
+      <TabsList className="flex w-full bg-transparent p-0 m-0 overflow-auto justify-start">
+        <Link href={`/community/${communityId}`}>
+          <TabsTrigger
+            value="chat"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("chat")}
+          </TabsTrigger>
+        </Link>
+        <Link href={`/community/${communityId}/votes`}>
+          <TabsTrigger
+            value="votes"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("votes")}
+          </TabsTrigger>
+        </Link>
+        <Link href={`/community/${communityId}/events`}>
+          <TabsTrigger
+            value="events"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("events")}
+          </TabsTrigger>
+        </Link>
+        <Link href={`/community/${communityId}/members`}>
+          <TabsTrigger
+            value="members"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("members")}
+          </TabsTrigger>
+        </Link>
+        <Link href={`/community/${communityId}/portfolio`}>
+          <TabsTrigger
+            value="portfolio"
+            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+          >
+            {t("portfolio")}
+          </TabsTrigger>
+        </Link>
+      </TabsList>
+      <Separator className="mb-3" />
+    </Tabs>
+  );
+}
+
+function EventPostPage({
+  eventId,
+  postId,
+  feedId,
+}: {
+  eventId: string;
+  postId: string;
+  feedId: string;
+}) {
   const { userId, getToken } = useAuth();
   const { data: userInfo } = useSuspenseQuery(
     userInfoOptions(getToken, userId),
   );
   const userProfileId = userInfo?.userId || "";
 
-  const { data: post } = useSuspenseQuery(
-    feedPost(postId, userProfileId || ""),
-  );
+  const { data: post } = useSuspenseQuery(feedPost(postId, userProfileId));
+  const { data: eventData } = useSuspenseQuery(eventOptions(eventId));
 
   const [editMode, setEditMode] = useState(false);
 
   const { onEditStandardPost, isEditing } = useFeedPostEditHandler(
-    orgType,
-    orgId,
+    "event",
+    eventId,
     feedId,
   );
   const { onReactionChange, isReacting } = useFeedPostReactionHandler(
-    orgType,
-    orgId,
+    "event",
+    eventId,
     feedId,
   );
   const { onDelete, isDeleting } = useFeedPostDeleteHandler(
-    orgType,
-    orgId,
+    "event",
+    eventId,
     feedId,
   );
 
@@ -87,28 +196,14 @@ export default function PostInfo({
   }
 
   return (
-    <div className="w-full flex flex-col gap-12">
-      {orgType === "community" && (
-        <CommunityPostInfo
-          post={post}
-          postId={postId}
-          communityId={orgId}
-          userId={userProfileId}
-          editMode={editMode}
-          onEditModeChange={setEditMode}
-          onEdit={onEdit}
-          isEditing={isEditing}
-          onReactionChange={onReactionChange}
-          isReacting={isReacting}
-          onDelete={onDelete}
-          isDeleting={isDeleting}
-        />
-      )}
-      {orgType === "event" && (
+    <div className="flex flex-col gap-8">
+      <EventInfoLayout eventId={eventId} data={eventData} />
+      <EventPostTabsNav eventId={eventId} />
+      <div className="flex flex-col gap-12">
         <EventPostInfo
           post={post}
           postId={postId}
-          eventId={orgId}
+          eventId={eventId}
           userId={userProfileId}
           editMode={editMode}
           onEditModeChange={setEditMode}
@@ -119,28 +214,127 @@ export default function PostInfo({
           onDelete={onDelete}
           isDeleting={isDeleting}
         />
-      )}
-
-      <div className="flex flex-col gap-4">
-        <Heading level={2}>Comments ({post.childrenCount})</Heading>
-        <PostCommentForm
-          orgType={orgType}
-          orgId={orgId}
-          parentId={post.post.localPostId}
-          form={form}
-        />
-
-        <div className="pl-6">
-          <Suspense fallback={<PostCardSkeleton />}>
-            <CommentsList
-              orgType={orgType}
-              orgId={orgId}
-              parentId={post.post.localPostId.toString()}
-              feedId={feedId}
-            />
-          </Suspense>
+        <div className="flex flex-col gap-4">
+          <Heading level={2}>Comments ({post.childrenCount})</Heading>
+          <PostCommentForm
+            orgType="event"
+            orgId={eventId}
+            parentId={post.post.localPostId}
+            form={form}
+          />
+          <div className="pl-6">
+            <Suspense fallback={<PostCardSkeleton />}>
+              <CommentsList
+                orgType="event"
+                orgId={eventId}
+                parentId={post.post.localPostId.toString()}
+                feedId={feedId}
+              />
+            </Suspense>
+          </div>
         </div>
       </div>
     </div>
+  );
+}
+
+function CommunityPostPage({
+  communityId,
+  postId,
+  feedId,
+}: {
+  communityId: string;
+  postId: string;
+  feedId: string;
+}) {
+  const { userId, getToken } = useAuth();
+  const { data: userInfo } = useSuspenseQuery(
+    userInfoOptions(getToken, userId),
+  );
+  const userProfileId = userInfo?.userId || "";
+
+  const { data: post } = useSuspenseQuery(feedPost(postId, userProfileId));
+
+  const [editMode, setEditMode] = useState(false);
+
+  const { onEditStandardPost, isEditing } = useFeedPostEditHandler(
+    "community",
+    communityId,
+    feedId,
+  );
+  const { onReactionChange, isReacting } = useFeedPostReactionHandler(
+    "community",
+    communityId,
+    feedId,
+  );
+  const { onDelete, isDeleting } = useFeedPostDeleteHandler(
+    "community",
+    communityId,
+    feedId,
+  );
+
+  const form = useForm<SocialFeedPostFormSchemaType>({
+    mode: "all",
+    resolver: zodResolver(socialFeedPostFormSchema),
+    defaultValues: {
+      kind: "STANDARD_POST",
+      content: "",
+      parentPostId: post.post?.localPostId,
+    },
+  });
+
+  const onEdit = async (
+    postId: string,
+    values: SocialFeedPostFormSchemaType,
+  ) => {
+    await onEditStandardPost(postId, values);
+    setEditMode(false);
+  };
+
+  if (!isStandardPost(post) && !isPollPost(post)) {
+    return null;
+  }
+
+  return (
+    <CommunityInfoLayout communityId={communityId}>
+      <div className="flex flex-col gap-8">
+        <CommunityPostTabsNav communityId={communityId} />
+        <div className="flex flex-col gap-12">
+          <CommunityPostInfo
+            post={post}
+            postId={postId}
+            communityId={communityId}
+            userId={userProfileId}
+            editMode={editMode}
+            onEditModeChange={setEditMode}
+            onEdit={onEdit}
+            isEditing={isEditing}
+            onReactionChange={onReactionChange}
+            isReacting={isReacting}
+            onDelete={onDelete}
+            isDeleting={isDeleting}
+          />
+          <div className="flex flex-col gap-4">
+            <Heading level={2}>Comments ({post.childrenCount})</Heading>
+            <PostCommentForm
+              orgType="community"
+              orgId={communityId}
+              parentId={post.post.localPostId}
+              form={form}
+            />
+            <div className="pl-6">
+              <Suspense fallback={<PostCardSkeleton />}>
+                <CommentsList
+                  orgType="community"
+                  orgId={communityId}
+                  parentId={post.post.localPostId.toString()}
+                  feedId={feedId}
+                />
+              </Suspense>
+            </div>
+          </div>
+        </div>
+      </div>
+    </CommunityInfoLayout>
   );
 }

--- a/app/(general)/feed/[orgType]/[orgId]/post/[postId]/post-info.tsx
+++ b/app/(general)/feed/[orgType]/[orgId]/post/[postId]/post-info.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from "@clerk/nextjs";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
@@ -156,6 +156,11 @@ function EventPostPage({
   const { data: eventData } = useSuspenseQuery(eventOptions(eventId));
 
   const [editMode, setEditMode] = useState(false);
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    tabsRef.current?.scrollIntoView({ block: "start" });
+  }, []);
 
   const { onEditStandardPost, isEditing } = useFeedPostEditHandler(
     "event",
@@ -198,7 +203,9 @@ function EventPostPage({
   return (
     <div className="flex flex-col gap-8">
       <EventInfoLayout eventId={eventId} data={eventData} />
-      <EventPostTabsNav eventId={eventId} />
+      <div ref={tabsRef}>
+        <EventPostTabsNav eventId={eventId} />
+      </div>
       <div className="flex flex-col gap-12">
         <EventPostInfo
           post={post}
@@ -256,6 +263,11 @@ function CommunityPostPage({
   const { data: post } = useSuspenseQuery(feedPost(postId, userProfileId));
 
   const [editMode, setEditMode] = useState(false);
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    tabsRef.current?.scrollIntoView({ block: "start" });
+  }, []);
 
   const { onEditStandardPost, isEditing } = useFeedPostEditHandler(
     "community",
@@ -298,7 +310,9 @@ function CommunityPostPage({
   return (
     <CommunityInfoLayout communityId={communityId}>
       <div className="flex flex-col gap-8">
-        <CommunityPostTabsNav communityId={communityId} />
+        <div ref={tabsRef}>
+          <CommunityPostTabsNav communityId={communityId} />
+        </div>
         <div className="flex flex-col gap-12">
           <CommunityPostInfo
             post={post}

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -690,7 +690,9 @@
     "sign-in-to-join-button": "Sign in to join",
     "joining-state": "Joining...",
     "join-community-button": "Join community",
-    "edit-community-button": "Edit community"
+    "edit-community-button": "Edit community",
+    "about-event": "About",
+    "discussion": "Discussion"
   },
   "community-create-form": {
     "log-in": "Log in to create a community",

--- a/app/i18n/messages/es.json
+++ b/app/i18n/messages/es.json
@@ -690,7 +690,9 @@
     "sign-in-to-join-button": "Inicia sesión para unirte",
     "joining-state": "Uniéndose...",
     "join-community-button": "Unirse a la comunidad",
-    "edit-community-button": "Editar comunidad"
+    "edit-community-button": "Editar comunidad",
+    "about-event": "Acerca de",
+    "discussion": "Discusión"
   },
   "community-create-form": {
     "log-in": "Inicia sesión para crear una comunidad",

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -690,7 +690,9 @@
     "sign-in-to-join-button": "Connectez-vous pour rejoindre",
     "joining-state": "Adhésion en cours...",
     "join-community-button": "Rejoindre la communauté",
-    "edit-community-button": "Modifier la communauté"
+    "edit-community-button": "Modifier la communauté",
+    "about-event": "À propos",
+    "discussion": "Discussion"
   },
   "community-create-form": {
     "log-in": "Connectez-vous pour créer une communauté",


### PR DESCRIPTION
## Summary

- Fetches and renders the event or community header info above the post on the post page
- Adds a tab navigation bar (Discussion/Chat tab active) matching the layout of the event/community feed pages
- Passes the event image / community banner as the `ScreenContainer` background for visual consistency

Closes #1064

## Changes

- `page.tsx`: prefetch event or community data server-side; pass background image to `ScreenContainer`
- `post-info.tsx`: split into `EventPostPage` / `CommunityPostPage` components; each renders the full org header (`EventInfoLayout` / `CommunityInfoLayout`) and a lightweight tab navigation (`EventPostTabsNav` / `CommunityPostTabsNav`) above the post and comments

## Test plan

- [x] Open a post from an event feed - event header and tabs (Discussion active) are visible above the post
- [x] Open a post from a community chat - community header and tabs (Chat active) are visible above the post
- [x] Tab links navigate correctly to the event/community pages
- [x] Post edit, reaction, delete, and comment submission still work
- [x] No regression on the event and community feed pages