### PR TITLE
fix(event-dashboard): redirect non-organizers to public event page instead of 404

### DIFF
--- a/app/(dashboard)/dashboard/event/[id]/(default)/layout.tsx
+++ b/app/(dashboard)/dashboard/event/[id]/(default)/layout.tsx
@@ -101,6 +101,6 @@ export default withEventRoleRestrictions(
   DashboardEventInfoLayoutProps,
   ["organizer", "gatekeeper"],
   {
-    notFoundOnFail: true,
+    redirectTo: (id) => `/event/${id}`,
   },
 );

--- a/lib/permissions/with-roles-required.tsx
+++ b/lib/permissions/with-roles-required.tsx
@@ -23,7 +23,7 @@ export function withEventRoleRestrictions<
   Component: ServerComponent<P>,
   allowedRoles: EventUserRole[],
   options?: {
-    redirectTo?: string;
+    redirectTo?: string | ((eventId: string) => string);
     notFoundOnFail?: boolean;
   },
 ): ServerComponent<P> {
@@ -51,7 +51,11 @@ export function withEventRoleRestrictions<
         notFound();
       }
 
-      redirect(options?.redirectTo ?? "/unauthorized");
+      const redirectTarget =
+        typeof options?.redirectTo === "function"
+          ? options.redirectTo(eventId)
+          : (options?.redirectTo ?? "/unauthorized");
+      redirect(redirectTarget);
     }
 
     return <Component {...props} />;


### PR DESCRIPTION
Closes #1072

## Summary

- Non-organizers/gatekeepers accessing an event dashboard now get redirected to `/event/:id` (public event page) instead of a 404.
- `withEventRoleRestrictions` now accepts `redirectTo` as a function `(eventId: string) => string` to enable dynamic redirects.

## Test plan

- [x] Log in as a community admin who is NOT the event organizer
- [x] Open the community dashboard > Events tab
- [x] Click on an event you did not create
- [x] Verify redirect to the public event page (not 404)
- [x] Verify event organizers still access the dashboard normally