### PR TITLE
fix(event-dashboard): redirect gatekeepers to participants page and hide general tab

### DIFF
--- a/app/(dashboard)/dashboard/event/[id]/(default)/dashboard-event-tabs.tsx
+++ b/app/(dashboard)/dashboard/event/[id]/(default)/dashboard-event-tabs.tsx
@@ -29,14 +29,16 @@ export default function DashboardEventTabs({
   return (
     <Tabs value={section} className="w-full min-h-[300px]">
       <TabsList className="flex w-full bg-transparent p-0 m-0 overflow-auto justify-start">
-        <Link href={`/dashboard/event/${eventId}`} scroll={false}>
-          <TabsTrigger
-            value="general"
-            className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
-          >
-            {t("general")}
-          </TabsTrigger>
-        </Link>
+        <RoleBasedViewMode roles={roles} allowedRoles={["organizer"]}>
+          <Link href={`/dashboard/event/${eventId}`} scroll={false}>
+            <TabsTrigger
+              value="general"
+              className="w-fit p-2 data-[state=active]:font-semibold hover:bg-secondary/80"
+            >
+              {t("general")}
+            </TabsTrigger>
+          </Link>
+        </RoleBasedViewMode>
         <Link href={`/dashboard/event/${eventId}/participants`} scroll={false}>
           <TabsTrigger
             value="participants"

--- a/app/(dashboard)/dashboard/event/[id]/(default)/page.tsx
+++ b/app/(dashboard)/dashboard/event/[id]/(default)/page.tsx
@@ -1,5 +1,26 @@
+import { redirect } from "next/navigation";
 import DashboardEventGeneral from "./dashboard-event-general";
+import { getQueryClient } from "@/lib/get-query-client";
+import { eventUserRoles } from "@/lib/queries/event-users";
+import getActor from "@/lib/utils/actor";
 
-export default function DashboardEventDetailsDescriptionPage() {
+export default async function DashboardEventDetailsDescriptionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: eventId } = await params;
+  const queryClient = getQueryClient();
+  const actor = await getActor();
+
+  if (actor) {
+    const roles = await queryClient.fetchQuery(
+      eventUserRoles(eventId, actor.actingAs),
+    );
+    if (roles.includes("gatekeeper") && !roles.includes("organizer")) {
+      redirect(`/dashboard/event/${eventId}/participants`);
+    }
+  }
+
   return <DashboardEventGeneral />;
 }


### PR DESCRIPTION
## Summary

- Gatekeepers who navigate to `/dashboard/event/:id` (general tab) are now automatically redirected to `/dashboard/event/:id/participants`.
- The "General" tab is hidden in the event dashboard tabs for users who only have the gatekeeper role (not organizer).

## Why

Gatekeepers only need access to the participants list. The general event editing page is not relevant to them and should not be reachable.

## How it works

- `page.tsx` (general tab): fetches roles from the cached query client (no extra network call) and redirects gatekeeper-only users to `/participants`.
- `dashboard-event-tabs.tsx`: wraps the General tab in `RoleBasedViewMode allowedRoles={["organizer"]}` so it only renders for organizers.

## Test plan

- [x] Log in as a gatekeeper (not organizer) for an event
- [x] Navigate to `/dashboard/event/:id` directly - verify redirect to `/participants`
- [x] Click the event row from the community events dashboard - verify landing on participants page
- [x] Verify the "General" tab is not visible for gatekeepers
- [x] Log in as an organizer - verify the General tab is still visible and accessible