### PR TITLE
fix(event): show both CTAs when user is both organizer and gatekeeper

### DIFF
--- a/components/features/event/event-dashboard-quick-access-banner.tsx
+++ b/components/features/event/event-dashboard-quick-access-banner.tsx
@@ -72,10 +72,21 @@ export default function EventDashboardQuickAccessBanner({
     return null;
   }
 
-  if (roles.includes("organizer")) {
+  const isOrganizer = roles.includes("organizer");
+  const isGatekeeper = roles.includes("gatekeeper");
+
+  if (isOrganizer && isGatekeeper) {
+    return (
+      <div className="flex flex-col gap-2">
+        <OrganizerQuickAccessBanner eventId={eventId} />
+        <GatekeeperQuickAccessBanner eventId={eventId} />
+      </div>
+    );
+  }
+
+  if (isOrganizer) {
     return <OrganizerQuickAccessBanner eventId={eventId} />;
   }
 
-  // Gatekeeper quick access banner
   return <GatekeeperQuickAccessBanner eventId={eventId} />;
 }


### PR DESCRIPTION
## Summary

- When a user is both organizer and gatekeeper on an event, the quick access banner on the public event page was only showing the organizer CTA ("Edit event"), hiding the gatekeeper CTA ("Start scanning tickets")
- Now both CTAs are displayed when the user holds both roles

## Root cause

In `EventDashboardQuickAccessBanner`, the `organizer` role check short-circuited before the `gatekeeper` check, so the gatekeeper banner was never rendered for dual-role users.

## Test plan

- [x] Log in as a user who is both organizer and gatekeeper on an event
- [x] Navigate to the public event page
- [x] Verify both "Edit event" and "Start scanning tickets" CTAs are visible
- [x] Log in as organizer only: only "Edit event" should appear
- [x] Log in as gatekeeper only: only "Start scanning tickets" should appear
- [x] Log in as a regular attendee: no banner should appear