### PR TITLE
fix(event-registration): show correct error when own email is already registered

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -152,7 +152,7 @@
     "email-placeholder": "Email...",
     "toast-confirmation": "You take part in the event!",
     "toast-already-registered-error": "Email(s) already registered for this event!",
-    "toast-default-error": "Error whille trying to register participants",
+    "toast-default-error": "Error while trying to register participants",
     "checkout-error-title": "Payment couldn't start",
     "checkout-error-note": "No charge was made.",
     "participants-list": "Participants list",

--- a/components/features/event/event-registration/index.tsx
+++ b/components/features/event/event-registration/index.tsx
@@ -218,19 +218,17 @@ export function EventRegistrationForm({
         setIsPending(false);
         return;
       }
-      if (
+      const isAlreadyRegistered =
         err instanceof Error &&
-        err.message !== "[unknown] user is already participant for this event"
-      ) {
+        err.message.includes("user is already participant for this event");
+      if (err instanceof Error && !isAlreadyRegistered) {
         captureException(err);
       }
       toast({
         variant: "destructive",
-        title:
-          err instanceof Error &&
-          err.message === "[unknown] user is already participant for this event"
-            ? t("toast-already-registered-error")
-            : t("toast-default-error"),
+        title: isAlreadyRegistered
+          ? t("toast-already-registered-error")
+          : t("toast-default-error"),
       });
     }
     setIsPending(false);


### PR DESCRIPTION
## Summary

- Use `.includes()` instead of strict equality when detecting the "already participant" error from connect-rpc, so the specific "Email(s) already registered for this event!" toast is shown even if the error prefix varies between the authenticated and unauthenticated call paths.
- Fix typo `"whille"` -> `"while"` in the English fallback registration error message (`en.json`).

Closes #1076

## Test plan

- [x] Not logged in: register for a free event with email `a@example.com`
- [x] Not logged in: try to register again with the same email in the **Your email** field — expect "Email(s) already registered for this event!" toast (not the generic one)
- [x] Not logged in: add an already-registered email in a **guest** field — same toast should still appear
- [x] Logged-in user trying to register when already a participant — same toast should still appear