### PR TITLE
fix(community): eliminate per-member role API calls on members tab

### DIFF
--- a/app/(general)/community/(general)/[id]/[tab]/members.tsx
+++ b/app/(general)/community/(general)/[id]/[tab]/members.tsx
@@ -42,8 +42,8 @@ function CommunityMembers({ communityId }: CommunityMembersProps) {
             >
               <Link href={`/profile/${member.entityId}`} className="block">
                 <CommunityMemberCard
-                  communityId={communityId}
                   userId={member.entityId}
+                  roles={member.roles}
                 />
               </Link>
             </Suspense>

--- a/components/user/community-member-card.tsx
+++ b/components/user/community-member-card.tsx
@@ -5,22 +5,15 @@ import { Card } from "../widgets/cards/card";
 import Text from "../widgets/texts/text";
 import { profileOptions } from "@/lib/queries/profile";
 import { deserializeWithFrontMatter } from "@/lib/serialization";
-import { profileDetailsSchema } from "@/types/schemas";
-import { communityUserRoles } from "@/lib/queries/community";
+import { CommunityUserRole, profileDetailsSchema } from "@/types/schemas";
 
 type CommunityMemberCardProps = {
-  communityId: string;
   userId: string;
+  roles: CommunityUserRole[];
 };
 
-function CommunityMemberCard({
-  communityId,
-  userId,
-}: CommunityMemberCardProps) {
+function CommunityMemberCard({ userId, roles }: CommunityMemberCardProps) {
   const { data: profile } = useSuspenseQuery(profileOptions(userId));
-  const { data: roles = [] } = useSuspenseQuery(
-    communityUserRoles(communityId, userId),
-  );
 
   if (!profile?.bio && !profile?.displayName && !profile?.avatarUri) {
     return null;


### PR DESCRIPTION
## Summary

- `CommunityMemberCard` was calling `communityUserRoles` (a `entityRoles` API call) for each member individually
- With 350 members, this resulted in 350 simultaneous requests, triggering HTTP 429 "Too many requests"
- The roles are already present in the `communityUsersWithRoles` response - they are now passed as a prop, removing all redundant calls

## Changes

- `CommunityMemberCard`: removed `communityUserRoles` query, accepts `roles: CommunityUserRole[]` as prop instead
- `members.tsx`: passes `member.roles` (already fetched) to each card

## Test plan

- [x] Go to a community with many members (e.g. `/community/4/members`)
- [x] Verify the member list loads fully without 429 errors
- [x] Verify role badges (member / administrator) still display correctly on each card

Closes #1078