### PR TITLE
fix(tickets): cancelled event still visible on /tickets page

### DIFF
--- a/backend/gzdb/db_communities.go
+++ b/backend/gzdb/db_communities.go
@@ -67,7 +67,7 @@ func (g *gormZenaoDB) ListCommunitiesByUserRoles(userID string, roles []string, 
 
 	query := g.db.Model(&Community{}).
 		Distinct().
-		Joins("INNER JOIN entity_roles ON entity_roles.org_id = communities.id").
+		Joins("INNER JOIN entity_roles ON entity_roles.org_id = communities.id AND entity_roles.deleted_at IS NULL").
 		Where("entity_roles.entity_type = ? AND entity_roles.entity_id = ? AND entity_roles.org_type = ? AND entity_roles.role IN ?",
 			zeni.EntityTypeUser, userIDInt, zeni.EntityTypeCommunity, roles).
 		Order("communities.id DESC")

--- a/backend/gzdb/db_events.go
+++ b/backend/gzdb/db_events.go
@@ -293,7 +293,7 @@ func (g *gormZenaoDB) ListEventsByUserRoles(userID string, roles []string, limit
 
 	query := g.db.Model(&Event{}).
 		Distinct().
-		Joins("INNER JOIN entity_roles ON entity_roles.org_id = events.id").
+		Joins("INNER JOIN entity_roles ON entity_roles.org_id = events.id AND entity_roles.deleted_at IS NULL").
 		Where("entity_roles.entity_type = ? AND entity_roles.entity_id = ? AND entity_roles.org_type = ? AND entity_roles.role IN ?",
 			zeni.EntityTypeUser, userIDInt, zeni.EntityTypeEvent, roles)
 

--- a/lib/mutations/event-cancel-participation.ts
+++ b/lib/mutations/event-cancel-participation.ts
@@ -56,6 +56,8 @@ export const useEventCancelParticipation = () => {
       queryClient.invalidateQueries(eventTicketsOpts);
       queryClient.invalidateQueries(eventUserRolesOpts);
       queryClient.invalidateQueries(eventUsersWithRoleOpts);
+      // Refresh the "my tickets" list so the cancelled event disappears from it
+      queryClient.invalidateQueries({ queryKey: ["eventsByParticipant"] });
     },
   });
 


### PR DESCRIPTION
## Root cause

Cancelling participation soft-deletes the user's `participant` entity_role (GORM sets `deleted_at`). But `ListEventsByUserRoles` joined `entity_roles` with a bare `INNER JOIN`:

```go
Joins("INNER JOIN entity_roles ON entity_roles.org_id = events.id")
```

GORM only applies its `deleted_at IS NULL` soft-delete guard to the **main model** (`events`), never to joined tables. So soft-deleted roles still matched the join, and cancelled events kept showing on `/tickets`.

Verified directly against the dev DB: for a user who had cancelled, the buggy join returned the cancelled events (37, 38, 41); the fixed join returns only the still-active one (37).

## Changes

- **`backend/gzdb/db_events.go`**: add `AND entity_roles.deleted_at IS NULL` to the join in `ListEventsByUserRoles`.
- **`backend/gzdb/db_communities.go`**: same latent bug in `ListCommunitiesByUserRoles`, fixed identically (removed community members would have lingered the same way).
- **`lib/mutations/event-cancel-participation.ts`**: invalidate the `eventsByParticipant` query after cancellation so the `/tickets` list refetches immediately.

## Test plan

- [x] DB-level proof: fixed join excludes soft-deleted participant roles
- [x] Register to an event, go to `/tickets` (event appears)
- [x] Cancel registration, return to `/tickets` (event must be gone)
- [x] Confirm community members list also drops removed members

Closes #1080