### PR TITLE
fix(scanner): restore ticket QR scanning and improve check-in UX

### DIFF
--- a/app/(dashboard)/dashboard/event/[id]/(actions)/scanner/event-ticket-scanner.tsx
+++ b/app/(dashboard)/dashboard/event/[id]/(actions)/scanner/event-ticket-scanner.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
+import { ConnectError } from "@connectrpc/connect";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useAuth } from "@clerk/nextjs";
 import * as ed from "@noble/ed25519";
 import { useTranslations } from "next-intl";
-import { Scanner } from "@yudiel/react-qr-scanner";
-import { Loader2, RefreshCcw } from "lucide-react";
+import { Loader2, RefreshCcw, Zap, ZapOff } from "lucide-react";
+import BarcodeScanner from "./scanner";
 import { CheckinConfirmationDialog } from "@/components/dialogs/check-in-confirmation-dialog";
 import { useEventCheckIn } from "@/lib/mutations/event-management";
 import { userInfoOptions } from "@/lib/queries/user";
@@ -55,6 +56,30 @@ export function EventTicketScanner({
 
   const [history, setHistory] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [scannerError, setScannerError] = useState<string | null>(null);
+  const [torch, setTorch] = useState(false);
+  const cameraContainerRef = useRef<HTMLDivElement>(null);
+
+  // React doesn't reliably set the `muted` *attribute* on <video> elements, so
+  // Android Chrome blocks autoplay and the react-webcam preview stays black
+  // (desktop autoplay is laxer, which is why it works there). Force the
+  // attributes on the rendered <video> and kick off playback when the stream
+  // attaches.
+  useEffect(() => {
+    const video = cameraContainerRef.current?.querySelector("video");
+    if (!video) {
+      return;
+    }
+    video.muted = true;
+    video.setAttribute("muted", "");
+    video.setAttribute("playsinline", "");
+    const play = () => {
+      video.play().catch(() => {});
+    };
+    play();
+    video.addEventListener("loadedmetadata", play);
+    return () => video.removeEventListener("loadedmetadata", play);
+  }, []);
 
   const updateHistory = (newSig: string) => {
     setLastSignature(newSig);
@@ -106,8 +131,15 @@ export function EventTicketScanner({
 
       updateHistory(signature);
     } catch (err) {
-      console.error("Error", err);
-      if (err instanceof Error) {
+      console.error("checkin error", err);
+      if (err instanceof z.ZodError) {
+        // The scanned QR isn't a ticket secret (wrong format/length).
+        setError(t("check-in-confirmation-dialog.description-invalid-ticket"));
+      } else if (err instanceof ConnectError) {
+        // Backend rejection (already checked in, unknown ticket, ...).
+        // rawMessage drops the "[code]" prefix that ConnectError.message adds.
+        setError(err.rawMessage);
+      } else if (err instanceof Error) {
         setError(err.message);
       } else {
         setError(t("check-in-confirmation-dialog.description-error"));
@@ -137,14 +169,58 @@ export function EventTicketScanner({
 
       <div className="w-full grid grid-cols-2 gap-8">
         <div className="md:max-w-[650px] max-md:col-span-2 self-start">
-          <Scanner
-            onScan={(result) => handleQRCodeValue(result[0].rawValue)}
-            allowMultiple
-            paused={isLoading || confirmDialogOpen}
-            classNames={{
-              container: "md:max-w-[650px] max-md:col-span-2 self-center",
-            }}
-          />
+          <div
+            ref={cameraContainerRef}
+            className="relative aspect-square w-full overflow-hidden rounded bg-black [&_video]:absolute [&_video]:inset-0 [&_video]:h-full [&_video]:w-full [&_video]:object-cover"
+          >
+            <BarcodeScanner
+              facingMode="environment"
+              torch={torch}
+              // BarcodeScanner streams continuously: onUpdate fires on every
+              // frame, with a result only when a code is decoded (otherwise the
+              // first arg is a NotFoundException we ignore). We gate on the
+              // loading/dialog state rather than stopping the stream, to avoid
+              // re-initialising the camera (slow and flickery on mobile).
+              onUpdate={(_err, result) => {
+                if (!result || isLoading || confirmDialogOpen) {
+                  return;
+                }
+                setScannerError(null);
+                handleQRCodeValue(result.getText());
+              }}
+              onError={(err) => {
+                console.error("scanner camera error", err);
+                setScannerError(typeof err === "string" ? err : err.message);
+              }}
+            />
+
+            {/* Scanning viewfinder (corner brackets) */}
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <div className="relative h-2/3 w-2/3">
+                <span className="absolute left-0 top-0 h-8 w-8 rounded-tl-lg border-l-4 border-t-4 border-white/90" />
+                <span className="absolute right-0 top-0 h-8 w-8 rounded-tr-lg border-r-4 border-t-4 border-white/90" />
+                <span className="absolute bottom-0 left-0 h-8 w-8 rounded-bl-lg border-b-4 border-l-4 border-white/90" />
+                <span className="absolute bottom-0 right-0 h-8 w-8 rounded-br-lg border-b-4 border-r-4 border-white/90" />
+              </div>
+            </div>
+
+            {/* Flashlight toggle */}
+            <Button
+              type="button"
+              variant="secondary"
+              size="icon"
+              onClick={() => setTorch((value) => !value)}
+              aria-label={t("toggle-flashlight")}
+              className="absolute bottom-3 right-3 z-10 rounded-full opacity-90"
+            >
+              {torch ? <ZapOff /> : <Zap />}
+            </Button>
+          </div>
+          {scannerError && (
+            <div className="mt-2 rounded bg-destructive/10 p-3">
+              <Text className="text-destructive">Camera: {scannerError}</Text>
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col h-full max-md:col-span-2 gap-6">

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -652,6 +652,7 @@
     "check-in-confirmation-dialog": {
       "title-success": "Ticket verified",
       "description-error": "Error while trying to validate your ticket",
+      "description-invalid-ticket": "This QR code is not a valid ticket",
       "title-error": "Invalid ticket",
       "description-success": "You can enter the venue",
       "close": "Close"
@@ -659,8 +660,9 @@
     "last-ticket-scanned": "Last ticket signed",
     "checkin-count": "Total tickets checked-in",
     "history-title": "Scanned tickets for event",
-    "no-tickets-scanned": "No tickets scanned yet",
-    "signature": "Signature"
+    "no-tickets-scanned": "No tickets scanned on this device",
+    "signature": "Signature",
+    "toggle-flashlight": "Toggle flashlight"
   },
   "cancel-registration-confirmation-dialog": {
     "title": "Cancel your participation",

--- a/app/i18n/messages/es.json
+++ b/app/i18n/messages/es.json
@@ -651,6 +651,7 @@
     "check-in-confirmation-dialog": {
       "title-success": "Entrada verificada",
       "description-error": "Error al intentar validar tu entrada",
+      "description-invalid-ticket": "Este código QR no es una entrada válida",
       "title-error": "Entrada inválida",
       "description-success": "Puedes entrar al recinto",
       "close": "Cerrar"
@@ -658,8 +659,9 @@
     "last-ticket-scanned": "Última entrada firmada",
     "checkin-count": "Total de entradas verificadas",
     "history-title": "Entradas escaneadas del evento",
-    "no-tickets-scanned": "Aún no se han escaneado entradas",
-    "signature": "Firma"
+    "no-tickets-scanned": "Ninguna entrada escaneada en este dispositivo",
+    "signature": "Firma",
+    "toggle-flashlight": "Encender/apagar la linterna"
   },
   "cancel-registration-confirmation-dialog": {
     "title": "Cancelar tu participación",

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -652,6 +652,7 @@
     "check-in-confirmation-dialog": {
       "title-success": "Billet vérifié",
       "description-error": "Erreur lors de la validation de votre billet",
+      "description-invalid-ticket": "Ce QR code n'est pas un billet valide",
       "title-error": "Billet invalide",
       "description-success": "Vous pouvez entrer",
       "close": "Fermer"
@@ -659,8 +660,9 @@
     "last-ticket-scanned": "Dernier billet scanné",
     "checkin-count": "Total de billets vérifiés",
     "history-title": "Billets scannés pour l'événement",
-    "no-tickets-scanned": "Aucun billet scanné encore",
-    "signature": "Signature"
+    "no-tickets-scanned": "Aucun billet scanné sur cet appareil",
+    "signature": "Signature",
+    "toggle-flashlight": "Activer/désactiver la lampe"
   },
   "cancel-registration-confirmation-dialog": {
     "title": "Annuler votre participation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@types/tz-lookup": "^6.1.2",
         "@vercel/otel": "^2.1.0",
         "@yornaath/batshit": "^0.11.1",
-        "@yudiel/react-qr-scanner": "^2.3.1",
         "bech32": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6712,11 +6711,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/emscripten": {
-      "version": "1.41.4",
-      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.4.tgz",
-      "integrity": "sha512-ECf0qTibhAi2Z0K6FIY96CvBTVkVIuVunOfbTUgbaAmGmbwsc33dbK9KZPROWsmzHotddy6C5pIqYqOmsBoJEw=="
-    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -7660,19 +7654,6 @@
       "resolved": "https://registry.npmjs.org/@yornaath/batshit-devtools/-/batshit-devtools-1.7.1.tgz",
       "integrity": "sha512-AyttV1Njj5ug+XqEWY1smV45dTWMlWKtj1B8jcFYgBKUFyUlF/qEhD+iP1E5UaRYW6hQRYD9T2WNDwFTrOMWzQ=="
     },
-    "node_modules/@yudiel/react-qr-scanner": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@yudiel/react-qr-scanner/-/react-qr-scanner-2.3.1.tgz",
-      "integrity": "sha512-fE7217QvMKT/AxAEeKIheFhkKO13PSGHiqJfg4dLK/SGPpelpXNpZZ0Qeph1Cm08/AqMlGhvzQbCmoPeD/VVIg==",
-      "dependencies": {
-        "barcode-detector": "3.0.3",
-        "webrtc-adapter": "9.0.3"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      }
-    },
     "node_modules/@zondax/ledger-cosmos-js": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@zondax/ledger-cosmos-js/-/ledger-cosmos-js-4.0.1.tgz",
@@ -8304,14 +8285,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/barcode-detector": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.0.3.tgz",
-      "integrity": "sha512-N07CNbpudOB3oIYm0tvaezCM6zy9HOlYnUCBhX6Q5UGhnqngyBgOf/p/5ZhqHxsf9/QYy5dX95RrblIs0hNaiw==",
-      "dependencies": {
-        "zxing-wasm": "^2.1.2"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -16547,11 +16520,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/sdp": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
-      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw=="
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -17532,6 +17500,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
       "engines": {
         "node": ">=20"
       },
@@ -19144,18 +19113,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/webrtc-adapter": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
-      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
-      "dependencies": {
-        "sdp": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.10.0"
-      }
-    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -19504,32 +19461,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/zxing-wasm": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-2.2.2.tgz",
-      "integrity": "sha512-Q9/B9whEwAUABvr7ScHl36wVZTBWVHAaumx45uGQLl2GGRp5ZRtDtwbz5scOwl/xzL07fximIqoQqqmzf9eJJA==",
-      "dependencies": {
-        "@types/emscripten": "^1.41.2",
-        "type-fest": "^5.0.1"
-      },
-      "peerDependencies": {
-        "@types/emscripten": ">=1.39.6"
-      }
-    },
-    "node_modules/zxing-wasm/node_modules/type-fest": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.1.0.tgz",
-      "integrity": "sha512-wQ531tuWvB6oK+pchHIu5lHe5f5wpSCqB8Kf4dWQRbOYc9HTge7JL0G4Qd44bh6QuJCccIzL3bugb8GI0MwHrg==",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/tz-lookup": "^6.1.2",
     "@vercel/otel": "^2.1.0",
     "@yornaath/batshit": "^0.11.1",
-    "@yudiel/react-qr-scanner": "^2.3.1",
     "bech32": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Closes #1086

## What

Restore ticket QR scanning (broken in production) and improve the check-in UX.

## Why it was broken

The scanner used `@yudiel/react-qr-scanner`, whose decoder (`barcode-detector` then `zxing-wasm`) fetches its WASM file from `fastly.jsdelivr.net` at scan time. The CSP `connect-src` (added on 2026-02-27 in `e18f16f6`, "Phase 0 foundation hardening") does not allow that domain, so the WASM never loads and the decoder throws "Barcode detection service unavailable". It kept appearing to work only on devices where the native Android `BarcodeDetector` took over.

## Changes

- Migrate to `react-qr-barcode-scanner` (already a dependency, based on `@zxing/library`), which bundles its decoder. No external CDN, no CSP change, works offline at the venue. Removes the `@yudiel/react-qr-scanner` dependency and its WASM chain.
- Force the `muted` / `playsinline` attributes and start playback so the camera preview is not black on Android (React does not reliably set the `muted` attribute, so Chrome blocks autoplay).
- Restore the viewfinder overlay and the flashlight (torch) toggle.
- Show clean check-in error messages (invalid QR code, backend message) instead of the raw Zod error JSON.
- Reword the empty history state to "on this device" so it no longer contradicts the server side total count.
- Add the `toggle-flashlight` and `description-invalid-ticket` i18n keys (EN/FR/ES).

## Tests

- `npm run lint`: clean.
- `npm run translations`: EN/FR/ES complete, no missing/duplicate/hardcoded strings.
- Manually validated on Android (camera preview, QR scan, check-in, flashlight) and on desktop.

## Notes

- No CSP change, so the "Phase 0 hardening" stays intact.
- Backend rejection messages are shown as returned by the server (English); localizing them would require mapping backend error codes on the front, out of scope here.
